### PR TITLE
Update LongIdAddTest to work with Azure Storage Library v9.4.2

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Azure/Microsoft.Bot.Builder.Azure.csproj
+++ b/libraries/Microsoft.Bot.Builder.Azure/Microsoft.Bot.Builder.Azure.csproj
@@ -51,13 +51,14 @@
 	<ItemGroup>
 		<PackageReference Include="AsyncUsageAnalyzers" Version="1.0.0-alpha003" PrivateAssets="all" />
 		<PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.1.2" />
+		<PackageReference Include="Microsoft.Azure.Storage.Blob" Version="9.4.2" />
+		<PackageReference Include="Microsoft.Azure.Storage.Common" Version="9.4.2" />
 		<PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
 		<PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.1" />
 		<PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta008" PrivateAssets="all" />
 		<PackageReference Include="System.Threading.Tasks.Extensions" Version="4.4.0" />
     <PackageReference Include="Microsoft.Bot.Builder" Condition=" '$(PackageVersion)' == '' " Version="4.0.0-local" />
     <PackageReference Include="Microsoft.Bot.Builder" Condition=" '$(PackageVersion)' != '' " Version="$(PackageVersion)" />
-    <PackageReference Include="WindowsAzure.Storage" Version="9.3.2" />
   </ItemGroup>
 
 	<ItemGroup>

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/AzureBlobTranscriptStoreTests.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/AzureBlobTranscriptStoreTests.cs
@@ -193,7 +193,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
 
         // These tests require Azure Storage Emulator v5.7
         [TestMethod]
-        [ExpectedException(typeof(AggregateException))]
+        [ExpectedException(typeof(StorageException))]
         public async Task LongIdAddTest()
         {
             var a = CreateActivity(0, 0, LongId);


### PR DESCRIPTION
Update `LongIdAddTest `from AzureStorageTranscriptStoreTests to work with Azure Storage Library v9.4.2

![imagen](https://user-images.githubusercontent.com/27219455/50485559-94762c00-09d4-11e9-94db-b22b3302b23c.png)
