### PR TITLE
[DO NOT MERGE][StyleCop] Treat Warnings as Errors 

### DIFF
--- a/BotBuilder-DotNet.ruleset
+++ b/BotBuilder-DotNet.ruleset
@@ -1,101 +1,188 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<RuleSet Name="Rules for StyleCop.Analyzers" Description="Code analysis rules for StyleCop.Analyzers.csproj." ToolsVersion="15.0">
+<RuleSet Name="Rules for StyleCop.Analyzers" Description="Source analysis rules treat as errors for BotBuilder-DotNet solution." ToolsVersion="15.0">
   <Rules AnalyzerId="AsyncUsageAnalyzers" RuleNamespace="AsyncUsageAnalyzers">
-    <Rule Id="AvoidAsyncVoid" Action="Warning" />
-    <Rule Id="UseConfigureAwait" Action="Warning" />
-  </Rules>
-
-  <Rules AnalyzerId="Microsoft.CodeAnalysis.CSharp" RuleNamespace="Microsoft.CodeAnalysis.CSharp">    
-    <Rule Id="CS1573" Action="None" />
-    <Rule Id="CS1591" Action="None" />  
-    <Rule Id="CS1712" Action="None" />
+    <Rule Id="AvoidAsyncVoid" Action="Error" />
+    <Rule Id="UseConfigureAwait" Action="Error" />
   </Rules>
 
   <Rules AnalyzerId="Microsoft.CodeAnalysis.CSharp.Features" RuleNamespace="Microsoft.CodeAnalysis.CSharp.Features">
     <Rule Id="IDE0003" Action="None" />
-    <Rule Id="IDE0043" Action="Warning" />
   </Rules>  
 
-  <Rules AnalyzerId="Microsoft.CodeAnalysis.VisualBasic.Features" RuleNamespace="Microsoft.CodeAnalysis.VisualBasic.Features">
-    <Rule Id="IDE0043" Action="Warning" />
-  </Rules>
-
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
-    <Rule Id="SA1101" Action="None" /> <!-- local calls prefixed with this -->       
-    <Rule Id="SA1129" Action="None" /> <!-- don't use value type constructor-->
+    <Rule Id="SA0001" Action="Error" />
+    <Rule Id="SA0002" Action="Error" />
+    <Rule Id="SA1000" Action="Error" />
+    <Rule Id="SA1001" Action="Error" />
+    <Rule Id="SA1002" Action="Error" />
+    <Rule Id="SA1003" Action="Error" />
+    <Rule Id="SA1004" Action="Error" />
+    <Rule Id="SA1005" Action="Error" />
+    <Rule Id="SA1006" Action="Error" />
+    <Rule Id="SA1007" Action="Error" />
+    <Rule Id="SA1008" Action="Error" />
+    <Rule Id="SA1009" Action="Error" />
+    <Rule Id="SA1010" Action="Error" />
+    <Rule Id="SA1011" Action="Error" />
+    <Rule Id="SA1012" Action="Error" />
+    <Rule Id="SA1013" Action="Error" />
+    <Rule Id="SA1014" Action="Error" />
+    <Rule Id="SA1015" Action="Error" />
+    <Rule Id="SA1016" Action="Error" />
+    <Rule Id="SA1017" Action="Error" />
+    <Rule Id="SA1018" Action="Error" />
+    <Rule Id="SA1019" Action="Error" />
+    <Rule Id="SA1020" Action="Error" />
+    <Rule Id="SA1021" Action="Error" />
+    <Rule Id="SA1022" Action="Error" />
+    <Rule Id="SA1023" Action="Error" />
+    <Rule Id="SA1024" Action="Error" />
+    <Rule Id="SA1025" Action="Error" />
+    <Rule Id="SA1026" Action="Error" />
+    <Rule Id="SA1027" Action="Error" />
+    <Rule Id="SA1028" Action="Error" />
+    <Rule Id="SA1100" Action="Error" />
+    <Rule Id="SA1101" Action="None" />
+    <Rule Id="SA1102" Action="Error" />
+    <Rule Id="SA1103" Action="Error" />
+    <Rule Id="SA1104" Action="Error" />
+    <Rule Id="SA1105" Action="Error" />
+    <Rule Id="SA1106" Action="Error" />
+    <Rule Id="SA1107" Action="Error" />
+    <Rule Id="SA1108" Action="Error" />
+    <Rule Id="SA1110" Action="Error" />
+    <Rule Id="SA1111" Action="Error" />
+    <Rule Id="SA1112" Action="Error" />
+    <Rule Id="SA1113" Action="Error" />
+    <Rule Id="SA1114" Action="Error" />
+    <Rule Id="SA1115" Action="Error" />
+    <Rule Id="SA1116" Action="Error" />
+    <Rule Id="SA1117" Action="Error" />
+    <Rule Id="SA1118" Action="Error" />
+    <Rule Id="SA1119" Action="Error" />
+    <Rule Id="SA1120" Action="Error" />
+    <Rule Id="SA1121" Action="Error" />
+    <Rule Id="SA1122" Action="Error" />
+    <Rule Id="SA1123" Action="Error" />
+    <Rule Id="SA1124" Action="Error" />
+    <Rule Id="SA1125" Action="Error" />
+    <Rule Id="SA1127" Action="Error" />
+    <Rule Id="SA1128" Action="Error" />
+    <Rule Id="SA1129" Action="None" />
+    <Rule Id="SA1130" Action="Error" />
+    <Rule Id="SA1131" Action="Error" />
+    <Rule Id="SA1132" Action="Error" />
+    <Rule Id="SA1133" Action="Error" />
+    <Rule Id="SA1134" Action="Error" />
+    <Rule Id="SA1135" Action="Error" />
+    <Rule Id="SA1136" Action="Error" />
+    <Rule Id="SA1137" Action="Error" />
+    <Rule Id="SA1139" Action="Error" />
     <Rule Id="SA1200" Action="None" />
-    <Rule Id="SA1214" Action="None"/>    <!-- encapsalate field in property-->
-    <Rule Id="SA1305" Action="Warning" />
+    <Rule Id="SA1201" Action="Error" />
+    <Rule Id="SA1202" Action="Error" />
+    <Rule Id="SA1203" Action="Error" />
+    <Rule Id="SA1204" Action="Error" />
+    <Rule Id="SA1205" Action="Error" />
+    <Rule Id="SA1206" Action="Error" />
+    <Rule Id="SA1207" Action="Error" />
+    <Rule Id="SA1208" Action="Error" />
+    <Rule Id="SA1209" Action="Error" />
+    <Rule Id="SA1210" Action="Error" />
+    <Rule Id="SA1211" Action="Error" />
+    <Rule Id="SA1212" Action="Error" />
+    <Rule Id="SA1213" Action="Error" />
+    <Rule Id="SA1214" Action="None" />
+    <Rule Id="SA1216" Action="Error" />
+    <Rule Id="SA1217" Action="Error" />
+    <Rule Id="SA1300" Action="Error" />
+    <Rule Id="SA1302" Action="Error" />
+    <Rule Id="SA1303" Action="Error" />
+    <Rule Id="SA1304" Action="Error" />
+    <Rule Id="SA1305" Action="Error" />
+    <Rule Id="SA1306" Action="Error" />
+    <Rule Id="SA1307" Action="Error" />
+    <Rule Id="SA1308" Action="Error" />
     <Rule Id="SA1309" Action="None" />
-    <Rule Id="SA1412" Action="Warning" />
+    <Rule Id="SA1310" Action="Error" />
+    <Rule Id="SA1311" Action="Error" />
+    <Rule Id="SA1312" Action="Error" />
+    <Rule Id="SA1313" Action="Error" />
+    <Rule Id="SA1314" Action="Error" />
+    <Rule Id="SA1400" Action="Error" />
+    <Rule Id="SA1401" Action="Error" />
+    <Rule Id="SA1402" Action="Error" />
+    <Rule Id="SA1403" Action="Error" />
+    <Rule Id="SA1404" Action="Error" />
+    <Rule Id="SA1405" Action="Error" />
+    <Rule Id="SA1406" Action="Error" />
+    <Rule Id="SA1407" Action="Error" />
+    <Rule Id="SA1408" Action="Error" />
+    <Rule Id="SA1410" Action="Error" />
+    <Rule Id="SA1411" Action="Error" />
+    <Rule Id="SA1412" Action="Error" />
+    <Rule Id="SA1413" Action="Error" />
+    <Rule Id="SA1500" Action="Error" />
+    <Rule Id="SA1501" Action="Error" />
+    <Rule Id="SA1502" Action="Error" />
+    <Rule Id="SA1503" Action="Error" />
+    <Rule Id="SA1504" Action="Error" />
+    <Rule Id="SA1505" Action="Error" />
+    <Rule Id="SA1506" Action="Error" />
+    <Rule Id="SA1507" Action="Error" />
+    <Rule Id="SA1508" Action="Error" />
+    <Rule Id="SA1509" Action="Error" />
+    <Rule Id="SA1510" Action="Error" />
+    <Rule Id="SA1511" Action="Error" />
+    <Rule Id="SA1512" Action="Error" />
+    <Rule Id="SA1513" Action="Error" />
+    <Rule Id="SA1514" Action="Error" />
+    <Rule Id="SA1515" Action="Error" />
+    <Rule Id="SA1516" Action="Error" />
+    <Rule Id="SA1517" Action="Error" />
+    <Rule Id="SA1518" Action="Error" />
+    <Rule Id="SA1519" Action="Error" />
+    <Rule Id="SA1520" Action="Error" />
     <Rule Id="SA1600" Action="None" />
-    <Rule Id="SA1609" Action="Warning" />
-    <Rule Id="SA1633" Action="None" /> 
+    <Rule Id="SA1601" Action="Error" />
+    <Rule Id="SA1602" Action="Error" />
+    <Rule Id="SA1604" Action="Error" />
+    <Rule Id="SA1605" Action="Error" />
+    <Rule Id="SA1606" Action="Error" />
+    <Rule Id="SA1607" Action="Error" />
+    <Rule Id="SA1608" Action="Error" />
+    <Rule Id="SA1609" Action="Error" />
+    <Rule Id="SA1610" Action="Error" />
+    <Rule Id="SA1611" Action="Error" />
+    <Rule Id="SA1612" Action="Error" />
+    <Rule Id="SA1613" Action="Error" />
+    <Rule Id="SA1614" Action="Error" />
+    <Rule Id="SA1615" Action="Error" />
+    <Rule Id="SA1616" Action="Error" />
+    <Rule Id="SA1617" Action="Error" />
+    <Rule Id="SA1618" Action="Error" />
+    <Rule Id="SA1619" Action="Error" />
+    <Rule Id="SA1620" Action="Error" />
+    <Rule Id="SA1621" Action="Error" />
+    <Rule Id="SA1622" Action="Error" />
+    <Rule Id="SA1623" Action="Error" />
+    <Rule Id="SA1624" Action="Error" />
+    <Rule Id="SA1625" Action="Error" />
+    <Rule Id="SA1626" Action="Error" />
+    <Rule Id="SA1627" Action="Error" />
+    <Rule Id="SA1629" Action="Error" />
+    <Rule Id="SA1633" Action="None" />
+    <Rule Id="SA1634" Action="Error" />
+    <Rule Id="SA1635" Action="Error" />
+    <Rule Id="SA1636" Action="Error" />
+    <Rule Id="SA1637" Action="Error" />
+    <Rule Id="SA1638" Action="Error" />
+    <Rule Id="SA1640" Action="Error" />
+    <Rule Id="SA1641" Action="Error" />
+    <Rule Id="SA1642" Action="Error" />
+    <Rule Id="SA1643" Action="Error" />
+    <Rule Id="SA1648" Action="Error" />
+    <Rule Id="SA1649" Action="Error" />
+    <Rule Id="SA1651" Action="Error" />
   </Rules>
-  
-  <Rules AnalyzerId="Microsoft.Analyzers.ManagedCodeAnalysis" RuleNamespace="Microsoft.Rules.Managed">
-    <Rule Id="CA1001" Action="Warning" />
-    <Rule Id="CA1009" Action="Warning" />
-    <Rule Id="CA1016" Action="Warning" />
-    <Rule Id="CA1033" Action="Warning" />
-    <Rule Id="CA1049" Action="Warning" />
-    <Rule Id="CA1060" Action="Warning" />
-    <Rule Id="CA1061" Action="Warning" />
-    <Rule Id="CA1063" Action="Warning" />
-    <Rule Id="CA1065" Action="Warning" />
-    <Rule Id="CA1301" Action="Warning" />
-    <Rule Id="CA1400" Action="Warning" />
-    <Rule Id="CA1401" Action="Warning" />
-    <Rule Id="CA1403" Action="Warning" />
-    <Rule Id="CA1404" Action="Warning" />
-    <Rule Id="CA1405" Action="Warning" />
-    <Rule Id="CA1410" Action="Warning" />
-    <Rule Id="CA1415" Action="Warning" />
-    <Rule Id="CA1821" Action="Warning" />
-    <Rule Id="CA1900" Action="Warning" />
-    <Rule Id="CA1901" Action="Warning" />
-    <Rule Id="CA2002" Action="Warning" />
-    <Rule Id="CA2100" Action="Warning" />
-    <Rule Id="CA2101" Action="Warning" />
-    <Rule Id="CA2108" Action="Warning" />
-    <Rule Id="CA2111" Action="Warning" />
-    <Rule Id="CA2112" Action="Warning" />
-    <Rule Id="CA2114" Action="Warning" />
-    <Rule Id="CA2116" Action="Warning" />
-    <Rule Id="CA2117" Action="Warning" />
-    <Rule Id="CA2122" Action="Warning" />
-    <Rule Id="CA2123" Action="Warning" />
-    <Rule Id="CA2124" Action="Warning" />
-    <Rule Id="CA2126" Action="Warning" />
-    <Rule Id="CA2131" Action="Warning" />
-    <Rule Id="CA2132" Action="Warning" />
-    <Rule Id="CA2133" Action="Warning" />
-    <Rule Id="CA2134" Action="Warning" />
-    <Rule Id="CA2137" Action="Warning" />
-    <Rule Id="CA2138" Action="Warning" />
-    <Rule Id="CA2140" Action="Warning" />
-    <Rule Id="CA2141" Action="Warning" />
-    <Rule Id="CA2146" Action="Warning" />
-    <Rule Id="CA2147" Action="Warning" />
-    <Rule Id="CA2149" Action="Warning" />
-    <Rule Id="CA2200" Action="Warning" />
-    <Rule Id="CA2202" Action="Warning" />
-    <Rule Id="CA2207" Action="Warning" />
-    <Rule Id="CA2212" Action="Warning" />
-    <Rule Id="CA2213" Action="Warning" />
-    <Rule Id="CA2214" Action="Warning" />
-    <Rule Id="CA2216" Action="Warning" />
-    <Rule Id="CA2220" Action="Warning" />
-    <Rule Id="CA2229" Action="Warning" />
-    <Rule Id="CA2231" Action="Warning" />
-    <Rule Id="CA2232" Action="Warning" />
-    <Rule Id="CA2235" Action="Warning" />
-    <Rule Id="CA2236" Action="Warning" />
-    <Rule Id="CA2237" Action="Warning" />
-    <Rule Id="CA2238" Action="Warning" />
-    <Rule Id="CA2240" Action="Warning" />
-    <Rule Id="CA2241" Action="Warning" />
-    <Rule Id="CA2242" Action="Warning" />
-  </Rules>
-
 </RuleSet>


### PR DESCRIPTION
Update the ruleset file to treat StyleCop warnings as errors

### Note: Do not merge until the last PR  [#1429](https://github.com/Microsoft/botbuilder-dotnet/pull/1429) was merge and the StyleCop warnings are fixed. 

![image](https://user-images.githubusercontent.com/37461749/54124432-28a33d00-43e1-11e9-92b3-6d4d68330213.png)
