### PR TITLE
[Azure] Fix 'PartitionKey value must be supplied for this operation' error

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Azure/CosmosDbStorage.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/CosmosDbStorage.cs
@@ -33,7 +33,6 @@ namespace Microsoft.Bot.Builder.Azure
         private readonly RequestOptions _documentCollectionCreationRequestOptions = null;
         private readonly RequestOptions _databaseCreationRequestOptions = null;
         private readonly IDocumentClient _client;
-        private readonly object cosmosDbStorageOptions;
         private string _collectionLink = null;
 
         /// <summary>

--- a/libraries/Microsoft.Bot.Builder.Azure/CosmosDbStorage.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/CosmosDbStorage.cs
@@ -143,8 +143,7 @@ namespace Microsoft.Bot.Builder.Azure
 
             // Ensure Initialization has been run
             await InitializeAsync().ConfigureAwait(false);
-            var options = new RequestOptions();
-            options.PartitionKey = new PartitionKey(this._partitionKey);
+            var options = new RequestOptions() { PartitionKey = new PartitionKey(this._partitionKey) };
 
             // Parallelize deletion
             var tasks = keys.Select(key =>

--- a/libraries/Microsoft.Bot.Builder.Azure/CosmosDbStorageOptions.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/CosmosDbStorageOptions.cs
@@ -13,6 +13,14 @@ namespace Microsoft.Bot.Builder.Azure
     public class CosmosDbStorageOptions
     {
         /// <summary>
+        /// Gets or sets the partitionKey value.
+        /// </summary>
+        /// <value>
+        /// The Partition Key.
+        /// </value>
+        public string PartitionKey { get; set; }
+
+        /// <summary>
         /// Gets or sets the CosmosDB endpoint.
         /// </summary>
         /// <value>


### PR DESCRIPTION
### Description
This PR will fix the Issue #N.

### Changes made

- Add `PartitionKey` field to the `CosmosDbStorageOptions`
- Modify the `DeleteAsync` method to generate the `RequestOptions `with the `PartitionKey `provided by the `CosmosDbStorageOptions`
- Pass the `options` optional parameter to the `DeleteDocumentAsync` method.
### Testing

1. [ Connect your bot to a CosmosDB](https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-howto-v4-storage?view=azure-bot-service-4.0&tabs=csharp)

1.  Add the following on the main bot class:
```
private const string CosmosServiceEndpoint = "Endpoint";
private const string CosmosDBKey = "YourDBKey";
private const string CosmosDBDatabaseName = "bot-cosmos-sql-db";
private const string CosmosDBCollectionName = "bot-storage";
private const string CosmosDBPartitionKey = "YourPartitionKey";

// Replaces Memory Storage with reference to Cosmos DB.
private static readonly CosmosDbStorage _myStorage = new CosmosDbStorage(new CosmosDbStorageOptions
{
    PartitionKey = CosmosDBPartitionKey,
    AuthKey = CosmosDBKey,
    CollectionId = CosmosDBCollectionName,
    CosmosDBEndpoint = new Uri(CosmosServiceEndpoint),
    DatabaseId = CosmosDBDatabaseName,
});
```
and

```
string[] utteranceList = { "id-to-delete" };
await _myStorage.DeleteAsync(utteranceList, cancellationToken);
```

On the EmptyBot, it should look something like [this](https://gist.github.com/Aliandi/483f7141550ceb8d2205545fbf25b46c).