### PR TITLE
[StyleCop] Fix all the warnings in the ApplicationInsights.Core.Tests

### DIFF
--- a/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/ServiceResolutionTests.cs
+++ b/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/ServiceResolutionTests.cs
@@ -2,11 +2,11 @@
 // Licensed under the MIT License.
 
 using System;
-using Microsoft.AspNetCore.Hosting;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Microsoft.AspNetCore.TestHost;
 using System.IO;
 using Microsoft.ApplicationInsights;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.Tests
 {
@@ -17,10 +17,11 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.Tests
         public ServiceResolutionTests()
         {
             // Arrange
-            //_server = new TestServer(new WebHostBuilder()
-                                     //.UseStartup<Startup>());
-            //_client = _server.CreateClient();
+            // _server = new TestServer(new WebHostBuilder()
+                                     // .UseStartup<Startup>());
+            // _client = _server.CreateClient();
         }
+
         [TestMethod]
         public void AppSettings_NoAppSettings()
         {
@@ -34,6 +35,7 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.Tests
             var telemetryClient = new TelemetryClient();
             Assert.IsTrue(string.IsNullOrWhiteSpace(telemetryClient.InstrumentationKey));
         }
+
         [TestMethod]
         public void AppSettings_NoAppInsights()
         {
@@ -42,6 +44,7 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.Tests
 
             var server = new TestServer(new WebHostBuilder()
                 .UseStartup<Startup>());
+
             // Telemetry Client should be active, just not configured.
             // This is not an error condition so samples can degrade.
             var telemetryClient = new TelemetryClient();
@@ -93,7 +96,6 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.Tests
             Assert.IsTrue(true);
         }
 
-
         [TestMethod]
         public void ServiceResolution_VerifyTelemetryClient()
         {
@@ -103,7 +105,6 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.Tests
                 .UseApplicationInsights()
                 .UseStartup<StartupVerifyTelemetryClient>());
         }
-
 
         [TestMethod]
         public void ServiceResolution_OverrideTelemetry()
@@ -135,38 +136,47 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.Tests
         }
 
         /// <summary>
-        /// Prepare appsettings.json for test
+        /// Prepare appsettings.json for test.
         /// </summary>
         /// <remarks>Ensures appsettings.json file is set up (copy based on different sample files,
-        /// post-pended with a version.)  ie, appsettings.json.no_app_insights </remarks>
+        /// post-pended with a version.)  ie, appsettings.json.no_app_insights. </remarks>
         /// <param name="version">Post-pended onto the file name to copy (ie, "no_app_insights"). If null, put no file.</param>
         public void ArrangeAppSettings(string version = "default")
         {
-            try { File.Delete("appsettings.json"); }
-            catch { }
-            
+            try
+            {
+                File.Delete("appsettings.json");
+            }
+            catch
+            {
+            }
+
             if (!string.IsNullOrWhiteSpace(version))
             {
                 File.Copy($"appsettings.json.{version}", "appsettings.json");
             }
         }
+
         /// <summary>
-        /// Prepare testbot.bot for test
+        /// Prepare testbot.bot for test.
         /// </summary>
         /// <remarks>Ensures testbot.bot file is set up (copy based on different sample files,
-        /// post-pended with a version.)  ie, testbot.bot.no_app_insights </remarks>
+        /// post-pended with a version.)  ie, testbot.bot.no_app_insights. </remarks>
         /// <param name="version">Post-pended onto the file name to copy (ie, "no_app_insights"). If null, put no file.</param>
-
         public void ArrangeBotFile(string version = "default")
         {
-            try { File.Delete("testbot.bot"); }
-            catch { }
-            
+            try
+            {
+                File.Delete("testbot.bot");
+            }
+            catch
+            {
+            }
+
             if (!string.IsNullOrWhiteSpace(version))
             {
                 File.Copy($"testbot.bot.{version}", "testbot.bot");
             }
         }
-
     }
 }

--- a/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/Startup.cs
+++ b/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/Startup.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.Tests
             var botConfig = BotConfiguration.Load("testbot.bot", null);
             services.AddBotApplicationInsights(botConfig);
 
-            // Adding IConfiguration in sample test server.  Otherwise this appears to be 
+            // Adding IConfiguration in sample test server.  Otherwise this appears to be
             // registered.
             services.AddSingleton<IConfiguration>(this.Configuration);
         }
@@ -39,6 +39,5 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.Tests
         {
             app.UseBotApplicationInsights();
         }
-
     }
 }

--- a/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/StartupInvalidInstance.cs
+++ b/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/StartupInvalidInstance.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.Tests
             var botConfig = BotConfiguration.Load("testbot.bot", null);
             services.AddBotApplicationInsights(botConfig, "invalidinstance");
 
-            // Adding IConfiguration in sample test server.  Otherwise this appears to be 
+            // Adding IConfiguration in sample test server.  Otherwise this appears to be
             // registered.
             services.AddSingleton<IConfiguration>(this.Configuration);
         }
@@ -44,6 +44,5 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.Tests
             Assert.IsNotNull(telemetryClient);
             Assert.IsTrue(telemetryClient is NullBotTelemetryClient);
         }
-
     }
 }

--- a/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/StartupMultipleAppInsights.cs
+++ b/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/StartupMultipleAppInsights.cs
@@ -34,12 +34,9 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.Tests
 
             services.AddBotApplicationInsights(botConfig, "instance2");
 
-
-            // Adding IConfiguration in sample test server.  Otherwise this appears to be 
+            // Adding IConfiguration in sample test server.  Otherwise this appears to be
             // registered.
             services.AddSingleton<IConfiguration>(this.Configuration);
-
-
         }
 
         public void Configure(IApplicationBuilder app, IHostingEnvironment env)
@@ -49,6 +46,5 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.Tests
             Assert.IsNotNull(telemetryClient);
             Assert.IsTrue(telemetryClient is BotTelemetryClient);
         }
-
     }
 }

--- a/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/StartupOverideTelemClient.cs
+++ b/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/StartupOverideTelemClient.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.Tests
     internal class StartupOverideTelemClient
     {
         private readonly Mock<IBotTelemetryClient> _telemClient;
+
         public StartupOverideTelemClient(IHostingEnvironment env)
         {
             var builder = new ConfigurationBuilder()
@@ -32,15 +33,11 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.Tests
         public void ConfigureServices(IServiceCollection services)
         {
             var botConfig = BotConfiguration.Load("testbot.bot", null);
-            
             services.AddBotApplicationInsights(_telemClient.Object);
 
-
-            // Adding IConfiguration in sample test server.  Otherwise this appears to be 
+            // Adding IConfiguration in sample test server.  Otherwise this appears to be
             // registered.
             services.AddSingleton<IConfiguration>(this.Configuration);
-
-
         }
 
         public void Configure(IApplicationBuilder app, IHostingEnvironment env)
@@ -50,6 +47,5 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.Tests
             Assert.IsNotNull(telemetryClient);
             Assert.AreEqual(telemetryClient, _telemClient.Object);
         }
-
     }
 }

--- a/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/StartupVerifyNullTelemetry.cs
+++ b/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/StartupVerifyNullTelemetry.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.Tests
             var botConfig = BotConfiguration.Load("testbot.bot", null);
             services.AddBotApplicationInsights(botConfig);
 
-            // Adding IConfiguration in sample test server.  Otherwise this appears to be 
+            // Adding IConfiguration in sample test server.  Otherwise this appears to be
             // registered.
             services.AddSingleton<IConfiguration>(this.Configuration);
         }
@@ -44,6 +44,5 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.Tests
             Assert.IsNotNull(telemetryClient);
             Assert.IsTrue(telemetryClient is NullBotTelemetryClient);
         }
-
     }
 }

--- a/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/StartupVerifyTelemetryClient.cs
+++ b/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/StartupVerifyTelemetryClient.cs
@@ -1,4 +1,4 @@
-﻿    // Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using Microsoft.AspNetCore.Builder;
@@ -31,12 +31,9 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.Tests
             var botConfig = BotConfiguration.Load("testbot.bot", null);
             services.AddBotApplicationInsights(botConfig);
 
-
-            // Adding IConfiguration in sample test server.  Otherwise this appears to be 
+            // Adding IConfiguration in sample test server.  Otherwise this appears to be
             // registered.
             services.AddSingleton<IConfiguration>(this.Configuration);
-
-            
         }
 
         public void Configure(IApplicationBuilder app, IHostingEnvironment env)
@@ -44,6 +41,5 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.Tests
             app.UseBotApplicationInsights();
             Assert.IsNotNull(app.ApplicationServices.GetService<IBotTelemetryClient>());
         }
-
     }
 }

--- a/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/TelemetryInitializerTests.cs
+++ b/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/TelemetryInitializerTests.cs
@@ -2,15 +2,15 @@
 // Licensed under the MIT License.
 
 using System;
-using Microsoft.ApplicationInsights;
 using System.Collections.Generic;
-using Microsoft.ApplicationInsights.Extensibility;
+using Microsoft.ApplicationInsights;
 using Microsoft.ApplicationInsights.Channel;
-using Moq;
 using Microsoft.ApplicationInsights.DataContracts;
+using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.AspNetCore.Http;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.Bot.Schema;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.Tests
@@ -22,7 +22,6 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.Tests
         [TestMethod]
         public void VerifyAllTelemtryPropoerties()
         {
-
             var configuration = new TelemetryConfiguration();
             var sentItems = new List<ITelemetry>();
             var mockTelemetryChannel = new Mock<ITelemetryChannel>();
@@ -71,7 +70,6 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.Tests
         [TestMethod]
         public void VerifyTraceProperties()
         {
-
             var configuration = new TelemetryConfiguration();
             var sentItems = new List<ITelemetry>();
             var mockTelemetryChannel = new Mock<ITelemetryChannel>();
@@ -113,13 +111,11 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.Tests
             Assert.IsTrue(telem.Properties["channelId"] == "CHANNELID");
             Assert.IsTrue(telem.Context.Session.Id == conversationID);
             Assert.IsTrue(telem.Context.User.Id == channelID + fromID);
-
         }
 
         [TestMethod]
         public void VerifyRequestProperties()
         {
-
             var configuration = new TelemetryConfiguration();
             var sentItems = new List<ITelemetry>();
             var mockTelemetryChannel = new Mock<ITelemetryChannel>();
@@ -161,14 +157,11 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.Tests
             Assert.IsTrue(telem.Properties["channelId"] == "CHANNELID");
             Assert.IsTrue(telem.Context.Session.Id == conversationID);
             Assert.IsTrue(telem.Context.User.Id == channelID + fromID);
-
         }
-
 
         [TestMethod]
         public void InvalidMessage_NoConversation()
         {
-
             var configuration = new TelemetryConfiguration();
             var sentItems = new List<ITelemetry>();
             var mockTelemetryChannel = new Mock<ITelemetryChannel>();
@@ -211,6 +204,5 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.Tests
             Assert.IsTrue(telem.Properties["hello"] == "value");
             Assert.IsTrue(telem.Metrics["metric"] == 0.6);
         }
-
     }
 }


### PR DESCRIPTION
- Remove Trailing white space
- Rename file to match with the class name