### PR TITLE
[StyleCop] Fix all the warnings on Bot.Builder.Dialogs.Tests

### DIFF
--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/ActivityPromptTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/ActivityPromptTests.cs
@@ -13,46 +13,28 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
     [TestClass]
     public class ActivityPromptTests
     {
-        private async Task<bool> _validator(PromptValidatorContext<Activity> promptContext, CancellationToken cancellationToken)
-        {
-            var activity = promptContext.Recognized.Value;
-            if (activity.Type == ActivityTypes.Event)
-            {
-                if ((int)activity.Value == 2)
-                {
-                    promptContext.Recognized.Value = MessageFactory.Text(activity.Value.ToString());
-                    return true;
-                }
-            }
-            else
-            {
-                await promptContext.Context.SendActivityAsync("Please send an 'event'-type Activity with a value of 2.");
-            }
-            return false;
-        }
-
         [TestMethod]
         [ExpectedException(typeof(ArgumentNullException))]
         public void ActivityPromptWithEmptyIdShouldFail()
         {
-            var emptyId = "";
-            var textPrompt = new EventActivityPrompt(emptyId, _validator);
+            var emptyId = string.Empty;
+            var textPrompt = new EventActivityPrompt(emptyId, Validator);
         }
 
         [TestMethod]
         [ExpectedException(typeof(ArgumentNullException))]
         public void ActivityPromptWithNullIdShouldFail()
         {
-            var nullId = "";
+            var nullId = string.Empty;
             nullId = null;
-            var textPrompt = new EventActivityPrompt(nullId, _validator);
+            var textPrompt = new EventActivityPrompt(nullId, Validator);
         }
-        
+
         [TestMethod]
         [ExpectedException(typeof(ArgumentNullException))]
         public void ActivityPromptWithNullValidatorShouldFail()
         {
-            var validator = (PromptValidator<Activity>)_validator;
+            var validator = (PromptValidator<Activity>)Validator;
             validator = null;
             var textPrompt = new EventActivityPrompt("EventActivityPrompt", validator);
         }
@@ -70,7 +52,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             var dialogs = new DialogSet(dialogState);
 
             // Create and add custom activity prompt to DialogSet.
-            var eventPrompt = new EventActivityPrompt("EventActivityPrompt", _validator);
+            var eventPrompt = new EventActivityPrompt("EventActivityPrompt", Validator);
             dialogs.Add(eventPrompt);
 
             // Create mock Activity for testing.
@@ -110,7 +92,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
 
             var dialogs = new DialogSet(dialogState);
 
-            var eventPrompt = new EventActivityPrompt("EventActivityPrompt", _validator);
+            var eventPrompt = new EventActivityPrompt("EventActivityPrompt", Validator);
             dialogs.Add(eventPrompt);
 
             var eventActivity = new Activity { Type = ActivityTypes.Event, Value = 2 };
@@ -173,7 +155,8 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                 {
                     var content = (Activity)results.Result;
                     await turnContext.SendActivityAsync(content, cancellationToken);
-                } else if (results.Status == DialogTurnStatus.Waiting)
+                }
+                else if (results.Status == DialogTurnStatus.Waiting)
                 {
                     await turnContext.SendActivityAsync("Test complete.");
                 }
@@ -215,6 +198,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                     var options = new PromptOptions { Prompt = new Activity { Type = ActivityTypes.Message, Text = "please send an event." } };
                     await dc.PromptAsync("EventActivityPrompt", options);
                 }
+
                 var secondResults = await eventPrompt.ResumeDialogAsync(dc, DialogReason.NextCalled);
 
                 if (secondResults.Status == DialogTurnStatus.Waiting)
@@ -228,13 +212,24 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             .AssertReply("Test complete.")
             .StartTestAsync();
         }
-    }
 
-    public class EventActivityPrompt : ActivityPrompt
-    {
-        public EventActivityPrompt(string dialogId, PromptValidator<Activity> validator)
-            : base(dialogId, validator)
+        private async Task<bool> Validator(PromptValidatorContext<Activity> promptContext, CancellationToken cancellationToken)
         {
+            var activity = promptContext.Recognized.Value;
+            if (activity.Type == ActivityTypes.Event)
+            {
+                if ((int)activity.Value == 2)
+                {
+                    promptContext.Recognized.Value = MessageFactory.Text(activity.Value.ToString());
+                    return true;
+                }
+            }
+            else
+            {
+                await promptContext.Context.SendActivityAsync("Please send an 'event'-type Activity with a value of 2.");
+            }
+
+            return false;
         }
     }
 }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/AttachmentPromptTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/AttachmentPromptTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
         [ExpectedException(typeof(ArgumentNullException))]
         public void AttachmentPromptWithEmptyIdShouldFail()
         {
-            var emptyId = "";
+            var emptyId = string.Empty;
             var attachmentPrompt = new AttachmentPrompt(emptyId);
         }
 
@@ -25,7 +25,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
         [ExpectedException(typeof(ArgumentNullException))]
         public void AttachmentPromptWithNullIdShouldFail()
         {
-            var nullId = "";
+            var nullId = string.Empty;
             nullId = null;
             var attachmentPrompt = new AttachmentPrompt(nullId);
         }
@@ -67,7 +67,6 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                     var attachments = results.Result as List<Attachment>;
                     var content = MessageFactory.Text((string)attachments[0].Content);
                     await turnContext.SendActivityAsync(content, cancellationToken);
-
                 }
             })
             .Send("hello")
@@ -111,7 +110,6 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                     var attachments = results.Result as List<Attachment>;
                     var content = MessageFactory.Text((string)attachments[0].Content);
                     await turnContext.SendActivityAsync(content, cancellationToken);
-
                 }
             })
             .Send("hello")

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/ChoicePromptTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/ChoicePromptTests.cs
@@ -18,11 +18,480 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
     [TestCategory("Choice Prompts")]
     public class ChoicePromptTests
     {
-        private List<Choice> colorChoices = new List<Choice> {
+        private List<Choice> colorChoices = new List<Choice>
+        {
             new Choice { Value = "red" },
             new Choice { Value = "green" },
-            new Choice { Value = "blue" }
+            new Choice { Value = "blue" },
         };
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void ChoicePromptWithEmptyIdShouldFail()
+        {
+            var emptyId = string.Empty;
+            var choicePrompt = new ChoicePrompt(emptyId);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void ChoicePromptWithNullIdShouldFail()
+        {
+            var nullId = string.Empty;
+            nullId = null;
+            var choicePrompt = new ChoicePrompt(nullId);
+        }
+
+        [TestMethod]
+        public async Task ShouldSendPrompt()
+        {
+            var convoState = new ConversationState(new MemoryStorage());
+            var dialogState = convoState.CreateProperty<DialogState>("dialogState");
+
+            var adapter = new TestAdapter()
+                .Use(new AutoSaveStateMiddleware(convoState));
+
+            // Create new DialogSet.
+            var dialogs = new DialogSet(dialogState);
+            dialogs.Add(new ChoicePrompt("ChoicePrompt", defaultLocale: Culture.English));
+
+            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
+            {
+                var dc = await dialogs.CreateContextAsync(turnContext, cancellationToken);
+
+                var results = await dc.ContinueDialogAsync(cancellationToken);
+                if (results.Status == DialogTurnStatus.Empty)
+                {
+                    await dc.PromptAsync(
+                        "ChoicePrompt",
+                        new PromptOptions
+                        {
+                            Prompt = new Activity { Type = ActivityTypes.Message, Text = "favorite color?" },
+                            Choices = colorChoices,
+                        },
+                        cancellationToken);
+                }
+            })
+            .Send("hello")
+            .AssertReply(StartsWithValidator("favorite color?"))
+            .StartTestAsync();
+        }
+
+        [TestMethod]
+        public async Task ShouldSendPromptAsAnInlineList()
+        {
+            var convoState = new ConversationState(new MemoryStorage());
+            var dialogState = convoState.CreateProperty<DialogState>("dialogState");
+
+            var adapter = new TestAdapter()
+                .Use(new AutoSaveStateMiddleware(convoState));
+
+            var dialogs = new DialogSet(dialogState);
+            dialogs.Add(new ChoicePrompt("ChoicePrompt", defaultLocale: Culture.English));
+
+            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
+            {
+                var dc = await dialogs.CreateContextAsync(turnContext, cancellationToken);
+
+                var results = await dc.ContinueDialogAsync();
+                if (results.Status == DialogTurnStatus.Empty)
+                {
+                    await dc.PromptAsync(
+                        "ChoicePrompt",
+                        new PromptOptions
+                        {
+                            Prompt = new Activity { Type = ActivityTypes.Message, Text = "favorite color?" },
+                            Choices = colorChoices,
+                        },
+                        cancellationToken);
+                }
+            })
+            .Send("hello")
+            .AssertReply("favorite color? (1) red, (2) green, or (3) blue")
+            .StartTestAsync();
+        }
+
+        [TestMethod]
+        public async Task ShouldSendPromptAsANumberedList()
+        {
+            var convoState = new ConversationState(new MemoryStorage());
+            var dialogState = convoState.CreateProperty<DialogState>("dialogState");
+
+            var adapter = new TestAdapter()
+                .Use(new AutoSaveStateMiddleware(convoState));
+
+            var dialogs = new DialogSet(dialogState);
+
+            // Create ChoicePrompt and change style to ListStyle.List which affects how choices are presented.
+            var listPrompt = new ChoicePrompt("ChoicePrompt", defaultLocale: Culture.English);
+            listPrompt.Style = ListStyle.List;
+            dialogs.Add(listPrompt);
+
+            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
+            {
+                var dc = await dialogs.CreateContextAsync(turnContext, cancellationToken);
+
+                var results = await dc.ContinueDialogAsync(cancellationToken);
+                if (results.Status == DialogTurnStatus.Empty)
+                {
+                    await dc.PromptAsync(
+                        "ChoicePrompt",
+                        new PromptOptions
+                        {
+                            Prompt = new Activity { Type = ActivityTypes.Message, Text = "favorite color?" },
+                            Choices = colorChoices,
+                        },
+                        cancellationToken);
+                }
+            })
+            .Send("hello")
+            .AssertReply("favorite color?\n\n   1. red\n   2. green\n   3. blue")
+            .StartTestAsync();
+        }
+
+        [TestMethod]
+        public async Task ShouldSendPromptUsingSuggestedActions()
+        {
+            var convoState = new ConversationState(new MemoryStorage());
+            var dialogState = convoState.CreateProperty<DialogState>("dialogState");
+
+            var adapter = new TestAdapter()
+                .Use(new AutoSaveStateMiddleware(convoState));
+
+            var dialogs = new DialogSet(dialogState);
+            var listPrompt = new ChoicePrompt("ChoicePrompt", defaultLocale: Culture.English);
+            listPrompt.Style = ListStyle.SuggestedAction;
+            dialogs.Add(listPrompt);
+
+            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
+            {
+                var dc = await dialogs.CreateContextAsync(turnContext, cancellationToken);
+
+                var results = await dc.ContinueDialogAsync(cancellationToken);
+                if (results.Status == DialogTurnStatus.Empty)
+                {
+                    await dc.PromptAsync(
+                        "ChoicePrompt",
+                        new PromptOptions
+                        {
+                            Prompt = new Activity { Type = ActivityTypes.Message, Text = "favorite color?" },
+                            Choices = colorChoices,
+                        },
+                        cancellationToken);
+                }
+            })
+            .Send("hello")
+            .AssertReply(SuggestedActionsValidator(
+                "favorite color?",
+                new SuggestedActions
+                {
+                    Actions = new List<CardAction>
+                    {
+                        new CardAction { Type = "imBack", Value = "red", Title = "red" },
+                        new CardAction { Type = "imBack", Value = "green", Title = "green" },
+                        new CardAction { Type = "imBack", Value = "blue", Title = "blue" },
+                    },
+                }))
+            .StartTestAsync();
+        }
+
+        [TestMethod]
+        public async Task ShouldSendPromptUsingHeroCard()
+        {
+            var convoState = new ConversationState(new MemoryStorage());
+            var dialogState = convoState.CreateProperty<DialogState>("dialogState");
+
+            var adapter = new TestAdapter()
+                .Use(new AutoSaveStateMiddleware(convoState));
+
+            var dialogs = new DialogSet(dialogState);
+            var listPrompt = new ChoicePrompt("ChoicePrompt", defaultLocale: Culture.English);
+            listPrompt.Style = ListStyle.HeroCard;
+            dialogs.Add(listPrompt);
+
+            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
+                {
+                    var dc = await dialogs.CreateContextAsync(turnContext, cancellationToken);
+
+                    var results = await dc.ContinueDialogAsync(cancellationToken);
+                    if (results.Status == DialogTurnStatus.Empty)
+                    {
+                        await dc.PromptAsync(
+                            "ChoicePrompt",
+                            new PromptOptions
+                            {
+                                Prompt = new Activity { Type = ActivityTypes.Message, Text = "favorite color?" },
+                                Choices = colorChoices,
+                            },
+                            cancellationToken);
+                    }
+                })
+                .Send("hello")
+                .AssertReply(HeroCardValidator(new HeroCard
+                    {
+                        Text = "favorite color?",
+                        Buttons = new List<CardAction>
+                        {
+                            new CardAction { Type = "imBack", Value = "red", Title = "red" },
+                            new CardAction { Type = "imBack", Value = "green", Title = "green" },
+                            new CardAction { Type = "imBack", Value = "blue", Title = "blue" },
+                        },
+                    }))
+                .StartTestAsync();
+        }
+
+        [TestMethod]
+        public async Task ShouldSendPromptWithoutAddingAList()
+        {
+            var convoState = new ConversationState(new MemoryStorage());
+            var dialogState = convoState.CreateProperty<DialogState>("dialogState");
+
+            var adapter = new TestAdapter()
+                .Use(new AutoSaveStateMiddleware(convoState));
+
+            var dialogs = new DialogSet(dialogState);
+
+            var listPrompt = new ChoicePrompt("ChoicePrompt", defaultLocale: Culture.English);
+            listPrompt.Style = ListStyle.None;
+            dialogs.Add(listPrompt);
+
+            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
+            {
+                var dc = await dialogs.CreateContextAsync(turnContext, cancellationToken);
+
+                var results = await dc.ContinueDialogAsync(cancellationToken);
+                if (results.Status == DialogTurnStatus.Empty)
+                {
+                    await dc.PromptAsync(
+                        "ChoicePrompt",
+                        new PromptOptions
+                        {
+                            Prompt = new Activity { Type = ActivityTypes.Message, Text = "favorite color?" },
+                            Choices = colorChoices,
+                        },
+                        cancellationToken);
+                }
+            })
+            .Send("hello")
+            .AssertReply("favorite color?")
+            .StartTestAsync();
+        }
+
+        [TestMethod]
+        public async Task ShouldSendPromptWithoutAddingAListButAddingSsml()
+        {
+            var convoState = new ConversationState(new MemoryStorage());
+            var dialogState = convoState.CreateProperty<DialogState>("dialogState");
+
+            var adapter = new TestAdapter()
+                .Use(new AutoSaveStateMiddleware(convoState));
+
+            var dialogs = new DialogSet(dialogState);
+
+            var listPrompt = new ChoicePrompt("ChoicePrompt", defaultLocale: Culture.English);
+            listPrompt.Style = ListStyle.None;
+            dialogs.Add(listPrompt);
+
+            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
+            {
+                var dc = await dialogs.CreateContextAsync(turnContext, cancellationToken);
+
+                var results = await dc.ContinueDialogAsync(cancellationToken);
+                if (results.Status == DialogTurnStatus.Empty)
+                {
+                    await dc.PromptAsync(
+                        "ChoicePrompt",
+                        new PromptOptions
+                        {
+                            Prompt = new Activity
+                            {
+                                Type = ActivityTypes.Message,
+                                Text = "favorite color?",
+                                Speak = "spoken prompt",
+                            },
+                            Choices = colorChoices,
+                        },
+                        cancellationToken);
+                }
+            })
+            .Send("hello")
+            .AssertReply(SpeakValidator("favorite color?", "spoken prompt"))
+            .StartTestAsync();
+        }
+
+        [TestMethod]
+        public async Task ShouldRecognizeAChoice()
+        {
+            var convoState = new ConversationState(new MemoryStorage());
+            var dialogState = convoState.CreateProperty<DialogState>("dialogState");
+
+            var adapter = new TestAdapter()
+                .Use(new AutoSaveStateMiddleware(convoState));
+
+            var dialogs = new DialogSet(dialogState);
+
+            var listPrompt = new ChoicePrompt("ChoicePrompt", defaultLocale: Culture.English);
+            listPrompt.Style = ListStyle.None;
+            dialogs.Add(listPrompt);
+
+            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
+            {
+                var dc = await dialogs.CreateContextAsync(turnContext, cancellationToken);
+
+                var results = await dc.ContinueDialogAsync(cancellationToken);
+                if (results.Status == DialogTurnStatus.Empty)
+                {
+                    await dc.PromptAsync(
+                        "ChoicePrompt",
+                        new PromptOptions
+                        {
+                            Prompt = new Activity { Type = ActivityTypes.Message, Text = "favorite color?" },
+                            Choices = colorChoices,
+                        },
+                        cancellationToken);
+                }
+                else if (results.Status == DialogTurnStatus.Complete)
+                {
+                    var choiceResult = (FoundChoice)results.Result;
+                    await turnContext.SendActivityAsync(MessageFactory.Text($"{choiceResult.Value}"), cancellationToken);
+                }
+            })
+            .Send("hello")
+            .AssertReply(StartsWithValidator("favorite color?"))
+            .Send("red")
+            .AssertReply("red")
+            .StartTestAsync();
+        }
+
+        [TestMethod]
+        public async Task ShouldNOTrecognizeOtherText()
+        {
+            var convoState = new ConversationState(new MemoryStorage());
+            var dialogState = convoState.CreateProperty<DialogState>("dialogState");
+
+            var adapter = new TestAdapter()
+                .Use(new AutoSaveStateMiddleware(convoState));
+
+            var dialogs = new DialogSet(dialogState);
+            var listPrompt = new ChoicePrompt("ChoicePrompt", defaultLocale: Culture.English);
+            listPrompt.Style = ListStyle.None;
+            dialogs.Add(listPrompt);
+
+            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
+            {
+                var dc = await dialogs.CreateContextAsync(turnContext, cancellationToken);
+
+                var results = await dc.ContinueDialogAsync(cancellationToken);
+                if (results.Status == DialogTurnStatus.Empty)
+                {
+                    await dc.PromptAsync(
+                        "ChoicePrompt",
+                        new PromptOptions
+                        {
+                            Prompt = new Activity { Type = ActivityTypes.Message, Text = "favorite color?" },
+                            RetryPrompt = new Activity { Type = ActivityTypes.Message, Text = "your favorite color, please?" },
+                            Choices = colorChoices,
+                        },
+                        cancellationToken);
+                }
+            })
+            .Send("hello")
+            .AssertReply(StartsWithValidator("favorite color?"))
+            .Send("what was that?")
+            .AssertReply("your favorite color, please?")
+            .StartTestAsync();
+        }
+
+        [TestMethod]
+        public async Task ShouldCallCustomValidator()
+        {
+            var convoState = new ConversationState(new MemoryStorage());
+            var dialogState = convoState.CreateProperty<DialogState>("dialogState");
+
+            var adapter = new TestAdapter()
+                .Use(new AutoSaveStateMiddleware(convoState));
+
+            var dialogs = new DialogSet(dialogState);
+
+            PromptValidator<FoundChoice> validator = async (promptContext, cancellationToken) =>
+            {
+                await promptContext.Context.SendActivityAsync(MessageFactory.Text("validator called"), cancellationToken);
+                return true;
+            };
+            var listPrompt = new ChoicePrompt("ChoicePrompt", validator, Culture.English);
+            listPrompt.Style = ListStyle.None;
+            dialogs.Add(listPrompt);
+
+            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
+            {
+                var dc = await dialogs.CreateContextAsync(turnContext, cancellationToken);
+
+                var results = await dc.ContinueDialogAsync(cancellationToken);
+                if (results.Status == DialogTurnStatus.Empty)
+                {
+                    await dc.PromptAsync(
+                        "ChoicePrompt",
+                        new PromptOptions
+                        {
+                            Prompt = new Activity { Type = ActivityTypes.Message, Text = "favorite color?" },
+                            Choices = colorChoices,
+                        },
+                        cancellationToken);
+                }
+            })
+            .Send("hello")
+            .AssertReply(StartsWithValidator("favorite color?"))
+            .Send("I'll take the red please.")
+            .AssertReply("validator called")
+            .StartTestAsync();
+        }
+
+        /*
+        [TestMethod]
+        public async Task ShouldHandleAnUndefinedRequest()
+        {
+            var convoState = new ConversationState(new MemoryStorage());
+            var testProperty = convoState.CreateProperty<Dictionary<string, object>>("test");
+
+            var adapter = new TestAdapter()
+                .Use(convoState);
+
+            PromptValidator<FoundChoice> validator = (context, promptContext, cancellationToken) =>
+            {
+                Assert.IsTrue(false);
+                return Task.CompletedTask;
+            };
+
+            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
+            {
+                var state = await testProperty.GetAsync(turnContext, () => new Dictionary<string, object>());
+                var prompt = new ChoicePrompt(Culture.English, validator);
+                prompt.Style = ListStyle.None;
+
+                var dialogCompletion = await prompt.ContinueDialogAsync(turnContext, state);
+                if (!dialogCompletion.IsActive && !dialogCompletion.IsCompleted)
+                {
+                    await prompt.BeginAsync(turnContext, state,
+                        new ChoicePromptOptions
+                        {
+                            PromptString = "favorite color?",
+                            Choices = ChoiceFactory.ToChoices(colorChoices)
+                        });
+                }
+                else if (dialogCompletion.IsActive && !dialogCompletion.IsCompleted)
+                {
+                    if (dialogCompletion.Result == null)
+                    {
+                        await turnContext.SendActivityAsync("NotRecognized");
+                    }
+                }
+            })
+            .Send("hello")
+            .AssertReply(StartsWithValidator("favorite color?"))
+            .Send("value shouldn't have been recognized.")
+            .AssertReply("NotRecognized")
+            .StartTestAsync();
+        }*/
 
         private Action<IActivity> StartsWithValidator(string expected)
         {
@@ -81,461 +550,5 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                 Assert.AreEqual(expectedSpeak, msg.Speak);
             };
         }
-
-        [TestMethod]
-        [ExpectedException(typeof(ArgumentNullException))]
-        public void ChoicePromptWithEmptyIdShouldFail()
-        {
-            var emptyId = "";
-            var choicePrompt = new ChoicePrompt(emptyId);
-        }
-
-        [TestMethod]
-        [ExpectedException(typeof(ArgumentNullException))]
-        public void ChoicePromptWithNullIdShouldFail()
-        {
-            var nullId = "";
-            nullId = null;
-            var choicePrompt = new ChoicePrompt(nullId);
-        }
-
-        [TestMethod]
-        public async Task ShouldSendPrompt()
-        {
-            var convoState = new ConversationState(new MemoryStorage());
-            var dialogState = convoState.CreateProperty<DialogState>("dialogState");
-
-            var adapter = new TestAdapter()
-                .Use(new AutoSaveStateMiddleware(convoState));
-
-            // Create new DialogSet.
-            var dialogs = new DialogSet(dialogState);
-            dialogs.Add(new ChoicePrompt("ChoicePrompt", defaultLocale: Culture.English));
-
-            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
-            {
-                var dc = await dialogs.CreateContextAsync(turnContext, cancellationToken);
-
-                var results = await dc.ContinueDialogAsync(cancellationToken);
-                if (results.Status == DialogTurnStatus.Empty)
-                {
-                    await dc.PromptAsync("ChoicePrompt",
-                        new PromptOptions
-                        {
-                            Prompt = new Activity { Type = ActivityTypes.Message, Text = "favorite color?" },
-                            Choices = colorChoices
-                        },
-                        cancellationToken);
-                }
-            })
-            .Send("hello")
-            .AssertReply(StartsWithValidator("favorite color?"))
-            .StartTestAsync();
-        }
-
-        [TestMethod]
-        public async Task ShouldSendPromptAsAnInlineList()
-        {
-            var convoState = new ConversationState(new MemoryStorage());
-            var dialogState = convoState.CreateProperty<DialogState>("dialogState");
-
-            var adapter = new TestAdapter()
-                .Use(new AutoSaveStateMiddleware(convoState));
-
-            var dialogs = new DialogSet(dialogState);
-            dialogs.Add(new ChoicePrompt("ChoicePrompt", defaultLocale: Culture.English));
-
-            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
-            {
-                var dc = await dialogs.CreateContextAsync(turnContext, cancellationToken);
-
-                var results = await dc.ContinueDialogAsync();
-                if (results.Status == DialogTurnStatus.Empty)
-                {
-                    await dc.PromptAsync("ChoicePrompt",
-                        new PromptOptions
-                        {
-                            Prompt = new Activity { Type = ActivityTypes.Message, Text = "favorite color?" },
-                            Choices = colorChoices
-                        },
-                        cancellationToken);
-                }
-            })
-            .Send("hello")
-            .AssertReply("favorite color? (1) red, (2) green, or (3) blue")
-            .StartTestAsync();
-        }
-
-        [TestMethod]
-        public async Task ShouldSendPromptAsANumberedList()
-        {
-            var convoState = new ConversationState(new MemoryStorage());
-            var dialogState = convoState.CreateProperty<DialogState>("dialogState");
-
-            var adapter = new TestAdapter()
-                .Use(new AutoSaveStateMiddleware(convoState));
-
-            var dialogs = new DialogSet(dialogState);
-
-            // Create ChoicePrompt and change style to ListStyle.List which affects how choices are presented.
-            var listPrompt = new ChoicePrompt("ChoicePrompt", defaultLocale: Culture.English);
-            listPrompt.Style = ListStyle.List;
-            dialogs.Add(listPrompt);
-
-            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
-            {
-                var dc = await dialogs.CreateContextAsync(turnContext, cancellationToken);
-
-                var results = await dc.ContinueDialogAsync(cancellationToken);
-                if (results.Status == DialogTurnStatus.Empty)
-                {
-                    await dc.PromptAsync("ChoicePrompt",
-                        new PromptOptions
-                        {
-                            Prompt = new Activity { Type = ActivityTypes.Message, Text = "favorite color?" },
-                            Choices = colorChoices
-                        },
-                        cancellationToken);
-                }
-            })
-            .Send("hello")
-            .AssertReply("favorite color?\n\n   1. red\n   2. green\n   3. blue")
-            .StartTestAsync();
-        }
-
-        [TestMethod]
-        public async Task ShouldSendPromptUsingSuggestedActions()
-        {
-            var convoState = new ConversationState(new MemoryStorage());
-            var dialogState = convoState.CreateProperty<DialogState>("dialogState");
-
-            var adapter = new TestAdapter()
-                .Use(new AutoSaveStateMiddleware(convoState));
-
-            var dialogs = new DialogSet(dialogState);
-            var listPrompt = new ChoicePrompt("ChoicePrompt", defaultLocale: Culture.English);
-            listPrompt.Style = ListStyle.SuggestedAction;
-            dialogs.Add(listPrompt);
-
-            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
-            {
-                var dc = await dialogs.CreateContextAsync(turnContext, cancellationToken);
-
-                var results = await dc.ContinueDialogAsync(cancellationToken);
-                if (results.Status == DialogTurnStatus.Empty)
-                {
-                    await dc.PromptAsync("ChoicePrompt",
-                        new PromptOptions
-                        {
-                            Prompt = new Activity { Type = ActivityTypes.Message, Text = "favorite color?" },
-                            Choices = colorChoices
-                        },
-                        cancellationToken);
-                }
-            })
-            .Send("hello")
-            .AssertReply(SuggestedActionsValidator("favorite color?",
-                new SuggestedActions
-                {
-                    Actions = new List<CardAction>
-                    {
-                        new CardAction { Type="imBack", Value="red", Title="red" },
-                        new CardAction { Type="imBack", Value="green", Title="green" },
-                        new CardAction { Type="imBack", Value="blue", Title="blue" },
-                    }
-                }))
-            .StartTestAsync();
-        }
-
-        [TestMethod]
-        public async Task ShouldSendPromptUsingHeroCard()
-        {
-            var convoState = new ConversationState(new MemoryStorage());
-            var dialogState = convoState.CreateProperty<DialogState>("dialogState");
-
-            var adapter = new TestAdapter()
-                .Use(new AutoSaveStateMiddleware(convoState));
-
-            var dialogs = new DialogSet(dialogState);
-            var listPrompt = new ChoicePrompt("ChoicePrompt", defaultLocale: Culture.English);
-            listPrompt.Style = ListStyle.HeroCard;
-            dialogs.Add(listPrompt);
-
-            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
-                {
-                    var dc = await dialogs.CreateContextAsync(turnContext, cancellationToken);
-
-                    var results = await dc.ContinueDialogAsync(cancellationToken);
-                    if (results.Status == DialogTurnStatus.Empty)
-                    {
-                        await dc.PromptAsync("ChoicePrompt",
-                            new PromptOptions
-                            {
-                                Prompt = new Activity { Type = ActivityTypes.Message, Text = "favorite color?" },
-                                Choices = colorChoices
-                            },
-                            cancellationToken);
-                    }
-                })
-                .Send("hello")
-                .AssertReply(HeroCardValidator(new HeroCard
-                    {
-                        Text = "favorite color?",
-                        Buttons = new List<CardAction>
-                        {
-                            new CardAction { Type="imBack", Value="red", Title="red" },
-                            new CardAction { Type="imBack", Value="green", Title="green" },
-                            new CardAction { Type="imBack", Value="blue", Title="blue" },
-                        }
-                    }))
-                .StartTestAsync();
-        }
-
-        [TestMethod]
-        public async Task ShouldSendPromptWithoutAddingAList()
-        {
-            var convoState = new ConversationState(new MemoryStorage());
-            var dialogState = convoState.CreateProperty<DialogState>("dialogState");
-
-            var adapter = new TestAdapter()
-                .Use(new AutoSaveStateMiddleware(convoState));
-
-            var dialogs = new DialogSet(dialogState);
-
-            var listPrompt = new ChoicePrompt("ChoicePrompt", defaultLocale: Culture.English);
-            listPrompt.Style = ListStyle.None;
-            dialogs.Add(listPrompt);
-
-            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
-            {
-                var dc = await dialogs.CreateContextAsync(turnContext, cancellationToken);
-
-                var results = await dc.ContinueDialogAsync(cancellationToken);
-                if (results.Status == DialogTurnStatus.Empty)
-                {
-                    await dc.PromptAsync("ChoicePrompt",
-                        new PromptOptions
-                        {
-                            Prompt = new Activity { Type = ActivityTypes.Message, Text = "favorite color?" },
-                            Choices = colorChoices
-                        },
-                        cancellationToken);
-                }
-            })
-            .Send("hello")
-            .AssertReply("favorite color?")
-            .StartTestAsync();
-        }
-
-        [TestMethod]
-        public async Task ShouldSendPromptWithoutAddingAListButAddingSsml()
-        {
-            var convoState = new ConversationState(new MemoryStorage());
-            var dialogState = convoState.CreateProperty<DialogState>("dialogState");
-
-            var adapter = new TestAdapter()
-                .Use(new AutoSaveStateMiddleware(convoState));
-
-            var dialogs = new DialogSet(dialogState);
-
-            var listPrompt = new ChoicePrompt("ChoicePrompt", defaultLocale: Culture.English);
-            listPrompt.Style = ListStyle.None;
-            dialogs.Add(listPrompt);
-
-            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
-            {
-                var dc = await dialogs.CreateContextAsync(turnContext, cancellationToken);
-
-                var results = await dc.ContinueDialogAsync(cancellationToken);
-                if (results.Status == DialogTurnStatus.Empty)
-                {
-                    await dc.PromptAsync("ChoicePrompt",
-                        new PromptOptions
-                        {
-                            Prompt = new Activity {
-                                Type = ActivityTypes.Message,
-                                Text = "favorite color?",
-                                Speak = "spoken prompt"
-                            },
-                            Choices = colorChoices
-                        },
-                        cancellationToken);
-                }
-            })
-            .Send("hello")
-            .AssertReply(SpeakValidator("favorite color?", "spoken prompt"))
-            .StartTestAsync();
-        }
-
-        [TestMethod]
-        public async Task ShouldRecognizeAChoice()
-        {
-            var convoState = new ConversationState(new MemoryStorage());
-            var dialogState = convoState.CreateProperty<DialogState>("dialogState");
-
-            var adapter = new TestAdapter()
-                .Use(new AutoSaveStateMiddleware(convoState));
-
-            var dialogs = new DialogSet(dialogState);
-
-            var listPrompt = new ChoicePrompt("ChoicePrompt", defaultLocale: Culture.English);
-            listPrompt.Style = ListStyle.None;
-            dialogs.Add(listPrompt);
-
-            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
-            {
-                var dc = await dialogs.CreateContextAsync(turnContext, cancellationToken);
-
-                var results = await dc.ContinueDialogAsync(cancellationToken);
-                if (results.Status == DialogTurnStatus.Empty)
-                {
-                    await dc.PromptAsync("ChoicePrompt",
-                        new PromptOptions
-                        {
-                            Prompt = new Activity { Type = ActivityTypes.Message, Text = "favorite color?" },
-                            Choices = colorChoices
-                        },
-                        cancellationToken);
-                }
-                else if (results.Status == DialogTurnStatus.Complete)
-                {
-                    var choiceResult = (FoundChoice)results.Result;
-                    await turnContext.SendActivityAsync(MessageFactory.Text($"{choiceResult.Value}"), cancellationToken);
-                }
-            })
-            .Send("hello")
-            .AssertReply(StartsWithValidator("favorite color?"))
-            .Send("red")
-            .AssertReply("red")
-            .StartTestAsync();
-        }
-
-        [TestMethod]
-        public async Task ShouldNOTrecognizeOtherText()
-        {
-            var convoState = new ConversationState(new MemoryStorage());
-            var dialogState = convoState.CreateProperty<DialogState>("dialogState");
-
-            var adapter = new TestAdapter()
-                .Use(new AutoSaveStateMiddleware(convoState));
-
-            var dialogs = new DialogSet(dialogState);
-            var listPrompt = new ChoicePrompt("ChoicePrompt", defaultLocale: Culture.English);
-            listPrompt.Style = ListStyle.None;
-            dialogs.Add(listPrompt);
-
-            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
-            {
-                var dc = await dialogs.CreateContextAsync(turnContext, cancellationToken);
-
-                var results = await dc.ContinueDialogAsync(cancellationToken);
-                if (results.Status == DialogTurnStatus.Empty)
-                {
-                    await dc.PromptAsync("ChoicePrompt",
-                        new PromptOptions
-                        {
-                            Prompt = new Activity { Type = ActivityTypes.Message, Text = "favorite color?" },
-                            RetryPrompt = new Activity { Type = ActivityTypes.Message, Text = "your favorite color, please?" },
-                            Choices = colorChoices
-                        },
-                        cancellationToken);
-                }
-            })
-            .Send("hello")
-            .AssertReply(StartsWithValidator("favorite color?"))
-            .Send("what was that?")
-            .AssertReply("your favorite color, please?")
-            .StartTestAsync();
-        }
-
-        [TestMethod]
-        public async Task ShouldCallCustomValidator()
-        {
-            var convoState = new ConversationState(new MemoryStorage());
-            var dialogState = convoState.CreateProperty<DialogState>("dialogState");
-
-            var adapter = new TestAdapter()
-                .Use(new AutoSaveStateMiddleware(convoState));
-
-            var dialogs = new DialogSet(dialogState);
-
-            PromptValidator<FoundChoice> validator = async (promptContext, cancellationToken) =>
-            {
-                await promptContext.Context.SendActivityAsync(MessageFactory.Text("validator called"), cancellationToken);
-                return true;
-            };
-            var listPrompt = new ChoicePrompt("ChoicePrompt", validator, Culture.English);
-            listPrompt.Style = ListStyle.None;
-            dialogs.Add(listPrompt);
-
-            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
-            {
-                var dc = await dialogs.CreateContextAsync(turnContext, cancellationToken);
-
-                var results = await dc.ContinueDialogAsync(cancellationToken);
-                if (results.Status == DialogTurnStatus.Empty)
-                {
-                    await dc.PromptAsync("ChoicePrompt",
-                        new PromptOptions
-                        {
-                            Prompt = new Activity { Type = ActivityTypes.Message, Text = "favorite color?" },
-                            Choices = colorChoices
-                        },
-                        cancellationToken);
-                }
-            })
-            .Send("hello")
-            .AssertReply(StartsWithValidator("favorite color?"))
-            .Send("I'll take the red please.")
-            .AssertReply("validator called")
-            .StartTestAsync();
-        }
-
-        /*
-        [TestMethod]
-        public async Task ShouldHandleAnUndefinedRequest()
-        {
-            var convoState = new ConversationState(new MemoryStorage());
-            var testProperty = convoState.CreateProperty<Dictionary<string, object>>("test");
-
-            var adapter = new TestAdapter()
-                .Use(convoState);
-
-            PromptValidator<FoundChoice> validator = (context, promptContext, cancellationToken) =>
-            {
-                Assert.IsTrue(false);
-                return Task.CompletedTask;
-            };
-
-            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
-            {
-                var state = await testProperty.GetAsync(turnContext, () => new Dictionary<string, object>());
-                var prompt = new ChoicePrompt(Culture.English, validator);
-                prompt.Style = ListStyle.None;
-
-                var dialogCompletion = await prompt.ContinueDialogAsync(turnContext, state);
-                if (!dialogCompletion.IsActive && !dialogCompletion.IsCompleted)
-                {
-                    await prompt.BeginAsync(turnContext, state,
-                        new ChoicePromptOptions
-                        {
-                            PromptString = "favorite color?",
-                            Choices = ChoiceFactory.ToChoices(colorChoices)
-                        });
-                }
-                else if (dialogCompletion.IsActive && !dialogCompletion.IsCompleted)
-                {
-                    if (dialogCompletion.Result == null)
-                    {
-                        await turnContext.SendActivityAsync("NotRecognized");
-                    }
-                }
-            })
-            .Send("hello")
-            .AssertReply(StartsWithValidator("favorite color?"))
-            .Send("value shouldn't have been recognized.")
-            .AssertReply("NotRecognized")
-            .StartTestAsync();
-        }*/
-        }
     }
+}

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/ChoicesRecognizersTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/ChoicesRecognizersTests.cs
@@ -12,26 +12,32 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
     [TestCategory("Choice Tests")]
     public class ChoicesRecognizersTests
     {
-        private static List<SortedValue> colorValues = new List<SortedValue> {
+        // FindChoices
+        private static List<string> colorChoices = new List<string> { "red", "green", "blue" };
+        private static List<string> overlappingChoices = new List<string> { "bread", "bread pudding", "pudding" };
+
+        private static List<SortedValue> colorValues = new List<SortedValue>
+        {
             new SortedValue { Value = "red", Index = 0 },
             new SortedValue { Value = "green", Index = 1 },
-            new SortedValue { Value = "blue", Index = 2 }
+            new SortedValue { Value = "blue", Index = 2 },
         };
 
-        private static List<SortedValue> overlappingValues = new List<SortedValue> {
+        private static List<SortedValue> overlappingValues = new List<SortedValue>
+        {
             new SortedValue { Value = "bread", Index = 0 },
             new SortedValue { Value = "bread pudding", Index = 1 },
-            new SortedValue { Value = "pudding", Index = 2 }
+            new SortedValue { Value = "pudding", Index = 2 },
         };
 
-        private static List<SortedValue> similarValues = new List<SortedValue> {
+        private static List<SortedValue> similarValues = new List<SortedValue>
+        {
             new SortedValue { Value = "option A", Index = 0 },
             new SortedValue { Value = "option B", Index = 1 },
-            new SortedValue { Value = "option C", Index = 2 }
+            new SortedValue { Value = "option C", Index = 2 },
         };
 
         // FindValues
-    
         [TestMethod]
         public void ShouldFindASimpleValueInAnSingleWordUtterance()
         {
@@ -78,11 +84,6 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             AssertValue(found[0], "option B", 1, 1.0f);
         }
 
-        // FindChoices
-
-        private static List<string> colorChoices = new List<string> { "red", "green", "blue" };
-        private static List<string> overlappingChoices = new List<string> { "bread", "bread pudding", "pudding" };
-
         [TestMethod]
         public void ShouldFindASingleChoiceInAnUtterance()
         {
@@ -120,7 +121,6 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
         }
 
         // RecognizeChoices
-
         [TestMethod]
         public void ShouldFindAChoiceInAnUtteranceByName()
         {
@@ -183,7 +183,6 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
         }
 
         // Helper functions
-
         private static void AssertResult<T>(ModelResult<T> result, int start, int end, string text)
         {
             Assert.AreEqual(start, result.Start);

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/ChoicesTokenizerTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/ChoicesTokenizerTests.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             Assert.AreEqual(start, token.Start);
             Assert.AreEqual(end, token.End);
             Assert.AreEqual(text, token.Text);
-            Assert.AreEqual((normalized ?? text), token.Normalized);
+            Assert.AreEqual(normalized ?? text, token.Normalized);
         }
     }
 }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/ComponentDialogTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/ComponentDialogTests.cs
@@ -86,7 +86,6 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             await Task.CompletedTask;
         }
 
-
         [TestMethod]
         public async Task TelemetryAddWaterfallTest()
         {
@@ -97,7 +96,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
 
             testComponentDialog.TelemetryClient = new MyBotTelemetryClient();
             testComponentDialog.AddDialog(new WaterfallDialog("C"));
-            
+
             Assert.IsTrue(testComponentDialog.FindDialog("C").TelemetryClient is MyBotTelemetryClient);
             await Task.CompletedTask;
         }
@@ -122,8 +121,6 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
 
             await Task.CompletedTask;
         }
-
-
 
         [TestMethod]
         public async Task BasicComponentDialogTest()
@@ -231,7 +228,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             var options = new Dictionary<string, string> { { "value", "test" } };
 
             var childComponent = new ComponentDialog("childComponent");
-            childComponent.AddDialog(new WaterfallDialog("childDialog", new WaterfallStep[]
+            var steps = new WaterfallStep[]
             {
                 async (step, ct) =>
                 {
@@ -243,12 +240,15 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                     Assert.AreEqual("test", (string)step.Result);
                     await step.Context.SendActivityAsync("Child finished.");
                     return await step.EndDialogAsync();
-                }
-            }));
+                },
+            };
+            childComponent.AddDialog(new WaterfallDialog(
+                "childDialog",
+                steps));
 
             var parentComponent = new ComponentDialog("parentComponent");
             parentComponent.AddDialog(childComponent);
-            parentComponent.AddDialog(new WaterfallDialog("parentDialog", new WaterfallStep[]
+            var steps1 = new WaterfallStep[]
             {
                 async (step, dc) =>
                 {
@@ -257,8 +257,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                     Assert.IsTrue(stepOptions.ContainsKey("value"));
                     await step.Context.SendActivityAsync($"Parent called with: {stepOptions["value"]}");
                     return await step.EndDialogAsync(stepOptions["value"]);
-                }
-            }));
+                },
+            };
+            parentComponent.AddDialog(new WaterfallDialog(
+                "parentDialog",
+                steps1));
 
             await new TestFlow(adapter, async (turnContext, cancellationToken) =>
             {
@@ -287,16 +290,21 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
 
         private static WaterfallDialog CreateWaterfall()
         {
-            return new WaterfallDialog("test-waterfall", new WaterfallStep[] {
+            var steps = new WaterfallStep[]
+                {
                 WaterfallStep1,
                 WaterfallStep2,
-            });
+            };
+            return new WaterfallDialog(
+                "test-waterfall",
+                steps);
         }
 
         private static async Task<DialogTurnResult> WaterfallStep1(WaterfallStepContext stepContext, CancellationToken cancellationToken)
         {
             return await stepContext.PromptAsync("number", new PromptOptions { Prompt = MessageFactory.Text("Enter a number.") }, cancellationToken);
         }
+
         private static async Task<DialogTurnResult> WaterfallStep2(WaterfallStepContext stepContext, CancellationToken cancellationToken)
         {
             if (stepContext.Values != null)
@@ -304,6 +312,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                 var numberResult = (int)stepContext.Result;
                 await stepContext.Context.SendActivityAsync(MessageFactory.Text($"Thanks for '{numberResult}'"), cancellationToken);
             }
+
             return await stepContext.PromptAsync("number", new PromptOptions { Prompt = MessageFactory.Text("Enter another number.") }, cancellationToken);
         }
 
@@ -314,6 +323,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                 var numberResult = (int)stepContext.Result;
                 await stepContext.Context.SendActivityAsync(MessageFactory.Text($"Got '{numberResult}'."), cancellationToken);
             }
+
             return await stepContext.BeginDialogAsync("TestComponentDialog", null, cancellationToken);
         }
 
@@ -332,20 +342,24 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             public TestNestedComponentDialog()
                 : base("TestNestedComponentDialog")
             {
-                AddDialog(new WaterfallDialog("test-waterfall", new WaterfallStep[] {
+                var steps = new WaterfallStep[]
+                {
                     WaterfallStep1,
                     WaterfallStep2,
                     WaterfallStep3,
-                }));
+                };
+                AddDialog(new WaterfallDialog(
+                    "test-waterfall",
+                    steps));
                 AddDialog(new NumberPrompt<int>("number", defaultLocale: Culture.English));
                 AddDialog(new TestComponentDialog());
             }
         }
+
         private class MyBotTelemetryClient : IBotTelemetryClient
         {
             public MyBotTelemetryClient()
             {
-
             }
 
             public void Flush()
@@ -378,8 +392,5 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                 throw new NotImplementedException();
             }
         }
-
     }
-
 }
-

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/ComponentDialogTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/ComponentDialogTests.cs
@@ -228,7 +228,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             var options = new Dictionary<string, string> { { "value", "test" } };
 
             var childComponent = new ComponentDialog("childComponent");
-            var steps = new WaterfallStep[]
+            var childSteps = new WaterfallStep[]
             {
                 async (step, ct) =>
                 {
@@ -244,11 +244,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             };
             childComponent.AddDialog(new WaterfallDialog(
                 "childDialog",
-                steps));
+                childSteps));
 
             var parentComponent = new ComponentDialog("parentComponent");
             parentComponent.AddDialog(childComponent);
-            var steps1 = new WaterfallStep[]
+            var parentSteps = new WaterfallStep[]
             {
                 async (step, dc) =>
                 {
@@ -261,7 +261,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             };
             parentComponent.AddDialog(new WaterfallDialog(
                 "parentDialog",
-                steps1));
+                parentSteps));
 
             await new TestFlow(adapter, async (turnContext, cancellationToken) =>
             {

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/ConfirmPromptTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/ConfirmPromptTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
         [ExpectedException(typeof(ArgumentNullException))]
         public void ConfirmPromptWithEmptyIdShouldFail()
         {
-            var emptyId = "";
+            var emptyId = string.Empty;
             var confirmPrompt = new ConfirmPrompt(emptyId);
         }
 
@@ -25,10 +25,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
         [ExpectedException(typeof(ArgumentNullException))]
         public void ConfirmPromptWithNullIdShouldFail()
         {
-            var nullId = "";
+            var nullId = string.Empty;
             nullId = null;
             var confirmPrompt = new ConfirmPrompt(nullId);
         }
+
         [TestMethod]
         public async Task ConfirmPrompt()
         {
@@ -94,13 +95,13 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                         Prompt = new Activity
                         {
                             Type = ActivityTypes.Message,
-                            Text = "Please confirm."
+                            Text = "Please confirm.",
                         },
                         RetryPrompt = new Activity
                         {
                             Type = ActivityTypes.Message,
-                            Text = "Please confirm, say 'yes' or 'no' or something like that."
-                        }
+                            Text = "Please confirm, say 'yes' or 'no' or something like that.",
+                        },
                     };
                     await dc.PromptAsync("ConfirmPrompt", options, cancellationToken);
                 }
@@ -179,6 +180,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
 
             var dialogs = new DialogSet(dialogState);
             var prompt = new ConfirmPrompt("ConfirmPrompt", defaultLocale: Culture.English);
+
             // Set options
             prompt.ChoiceOptions = new Choices.ChoiceFactoryOptions { IncludeNumbers = true };
             prompt.Style = Choices.ListStyle.Inline;
@@ -196,13 +198,13 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                         Prompt = new Activity
                         {
                             Type = ActivityTypes.Message,
-                            Text = "Please confirm."
+                            Text = "Please confirm.",
                         },
                         RetryPrompt = new Activity
                         {
                             Type = ActivityTypes.Message,
-                            Text = "Please confirm, say 'yes' or 'no' or something like that."
-                        }
+                            Text = "Please confirm, say 'yes' or 'no' or something like that.",
+                        },
                     };
                     await dc.PromptAsync("ConfirmPrompt", options, cancellationToken);
                 }
@@ -238,6 +240,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
 
             var dialogs = new DialogSet(dialogState);
             var prompt = new ConfirmPrompt("ConfirmPrompt", defaultLocale: Culture.English);
+
             // Set options
             prompt.ChoiceOptions = new Choices.ChoiceFactoryOptions { IncludeNumbers = true };
             prompt.Style = Choices.ListStyle.Inline;
@@ -255,13 +258,13 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                         Prompt = new Activity
                         {
                             Type = ActivityTypes.Message,
-                            Text = "Please confirm."
+                            Text = "Please confirm.",
                         },
                         RetryPrompt = new Activity
                         {
                             Type = ActivityTypes.Message,
-                            Text = "Please confirm, say 'yes' or 'no' or something like that."
-                        }
+                            Text = "Please confirm, say 'yes' or 'no' or something like that.",
+                        },
                     };
                     await dc.PromptAsync("ConfirmPrompt", options, cancellationToken);
                 }
@@ -299,10 +302,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
 
             var dialogs = new DialogSet(dialogState);
             var prompt = new ConfirmPrompt("ConfirmPrompt", defaultLocale: Culture.English);
+
             // Set options
             prompt.ChoiceOptions = new Choices.ChoiceFactoryOptions { IncludeNumbers = false, InlineSeparator = "~" };
             dialogs.Add(prompt);
-
 
             await new TestFlow(adapter, async (turnContext, cancellationToken) =>
             {
@@ -316,13 +319,13 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                         Prompt = new Activity
                         {
                             Type = ActivityTypes.Message,
-                            Text = "Please confirm."
+                            Text = "Please confirm.",
                         },
                         RetryPrompt = new Activity
                         {
                             Type = ActivityTypes.Message,
-                            Text = "Please confirm, say 'yes' or 'no' or something like that."
-                        }
+                            Text = "Please confirm, say 'yes' or 'no' or something like that.",
+                        },
                     };
                     await dc.PromptAsync("ConfirmPrompt", options, cancellationToken);
                 }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/DateTimePromptTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/DateTimePromptTests.cs
@@ -141,17 +141,18 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             if (prompt.Recognized.Succeeded)
             {
                 var resolution = prompt.Recognized.Value.First();
+
                 // re-write the resolution to just include the date part.
                 var rewrittenResolution = new DateTimeResolution
                 {
                     Timex = resolution.Timex.Split('T')[0],
-                    Value = resolution.Value.Split(' ')[0]
+                    Value = resolution.Value.Split(' ')[0],
                 };
                 prompt.Recognized.Value = new List<DateTimeResolution> { rewrittenResolution };
                 return Task.FromResult(true);
             }
+
             return Task.FromResult(false);
         }
     }
 }
-

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/DialogSetTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/DialogSetTests.cs
@@ -11,7 +11,6 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
     [TestClass]
     public class DialogSetTests
     {
-
         [TestMethod]
         public void DialogSet_ConstructorValid()
         {
@@ -72,8 +71,8 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             Assert.IsTrue(ds.Find("A").TelemetryClient is NullBotTelemetryClient, "A not NullBotTelemetryClient");
             Assert.IsTrue(ds.Find("B").TelemetryClient is NullBotTelemetryClient, "A not NullBotTelemetryClient");
 
-            var myTelemetryClient = new MyBotTelemetryClient();
-            ds.TelemetryClient = myTelemetryClient;
+            var botTelemetryClient = new MyBotTelemetryClient();
+            ds.TelemetryClient = botTelemetryClient;
 
             Assert.IsTrue(ds.Find("A").TelemetryClient is MyBotTelemetryClient, "A not MyBotTelemetryClient");
             Assert.IsTrue(ds.Find("B").TelemetryClient is MyBotTelemetryClient, "A not MyBotTelemetryClient");
@@ -83,7 +82,6 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
         [TestMethod]
         public async Task DialogSet_NullTelemetrySet()
         {
-
             var convoState = new ConversationState(new MemoryStorage());
             var dialogStateProperty = convoState.CreateProperty<DialogState>("dialogstate");
             var ds = new DialogSet(dialogStateProperty)
@@ -95,13 +93,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             Assert.IsTrue(ds.Find("A").TelemetryClient is NullBotTelemetryClient, "A not NullBotTelemetryClient");
             Assert.IsTrue(ds.Find("B").TelemetryClient is NullBotTelemetryClient, "A not NullBotTelemetryClient");
             await Task.CompletedTask;
-
         }
 
         [TestMethod]
         public async Task DialogSet_AddTelemetrySet()
         {
-
             var convoState = new ConversationState(new MemoryStorage());
             var dialogStateProperty = convoState.CreateProperty<DialogState>("dialogstate");
             var ds = new DialogSet(dialogStateProperty)
@@ -118,7 +114,6 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
         [TestMethod]
         public async Task DialogSet_HeterogeneousLoggers()
         {
-
             var convoState = new ConversationState(new MemoryStorage());
             var dialogStateProperty = convoState.CreateProperty<DialogState>("dialogstate");
             var ds = new DialogSet(dialogStateProperty)
@@ -135,12 +130,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             await Task.CompletedTask;
         }
 
-
         private class MyBotTelemetryClient : IBotTelemetryClient
         {
             public MyBotTelemetryClient()
             {
-
             }
 
             public void Flush()
@@ -173,6 +166,5 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                 throw new NotImplementedException();
             }
         }
-
     }
 }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/EventActivityPrompt.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/EventActivityPrompt.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Bot.Builder.Adapters;
+using Microsoft.Bot.Schema;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.Bot.Builder.Dialogs.Tests
+{
+
+    public class EventActivityPrompt : ActivityPrompt
+    {
+        public EventActivityPrompt(string dialogId, PromptValidator<Activity> validator)
+            : base(dialogId, validator)
+        {
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/MyWaterfallDialog.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/MyWaterfallDialog.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Bot.Builder.Adapters;
+using Microsoft.Bot.Schema;
+using Microsoft.Recognizers.Text;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.Bot.Builder.Dialogs.Tests
+{
+
+    public class MyWaterfallDialog : WaterfallDialog
+    {
+        public MyWaterfallDialog(string id)
+            : base(id)
+        {
+            AddStep(Waterfall2_Step1);
+            AddStep(Waterfall2_Step2);
+            AddStep(Waterfall2_Step3);
+        }
+
+        private static async Task<DialogTurnResult> Waterfall2_Step1(WaterfallStepContext stepContext, CancellationToken cancellationToken)
+        {
+            await stepContext.Context.SendActivityAsync("step1");
+            return Dialog.EndOfTurn;
+        }
+
+        private static async Task<DialogTurnResult> Waterfall2_Step2(WaterfallStepContext stepContext, CancellationToken cancellationToken)
+        {
+            await stepContext.Context.SendActivityAsync("step2");
+            return Dialog.EndOfTurn;
+        }
+
+        private static async Task<DialogTurnResult> Waterfall2_Step3(WaterfallStepContext stepContext, CancellationToken cancellationToken)
+        {
+            await stepContext.Context.SendActivityAsync("step3");
+            return Dialog.EndOfTurn;
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/NumberPromptTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/NumberPromptTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
         [ExpectedException(typeof(ArgumentNullException))]
         public void NumberPromptWithEmptyIdShouldFail()
         {
-            var emptyId = "";
+            var emptyId = string.Empty;
             var numberPrompt = new NumberPrompt<int>(emptyId);
         }
 
@@ -25,7 +25,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
         [ExpectedException(typeof(ArgumentNullException))]
         public void NumberPromptWithNullIdShouldFail()
         {
-            var nullId = "";
+            var nullId = string.Empty;
             nullId = null;
             var numberPrompt = new NumberPrompt<int>(nullId);
         }
@@ -79,7 +79,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                 .Use(new AutoSaveStateMiddleware(convoState));
 
             var dialogs = new DialogSet(dialogState);
-            
+
             var numberPrompt = new NumberPrompt<int>("NumberPrompt", defaultLocale: Culture.English);
             dialogs.Add(numberPrompt);
 
@@ -90,9 +90,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                 var results = await dc.ContinueDialogAsync(cancellationToken);
                 if (results.Status == DialogTurnStatus.Empty)
                 {
-                    var options = new PromptOptions {
+                    var options = new PromptOptions
+                    {
                         Prompt = new Activity { Type = ActivityTypes.Message, Text = "Enter a number." },
-                        RetryPrompt = new Activity {  Type = ActivityTypes.Message, Text = "You must enter a number." }
+                        RetryPrompt = new Activity { Type = ActivityTypes.Message, Text = "You must enter a number." },
                     };
                     await dc.PromptAsync("NumberPrompt", options, cancellationToken);
                 }
@@ -125,11 +126,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             PromptValidator<int> validator = (promptContext, cancellationToken) =>
             {
                 var result = promptContext.Recognized.Value;
-                
+
                 if (result < 100 && result > 0)
                 {
                     return Task.FromResult(true);
                 }
+
                 return Task.FromResult(false);
             };
             var numberPrompt = new NumberPrompt<int>("NumberPrompt", validator, Culture.English);
@@ -142,9 +144,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                 var results = await dc.ContinueDialogAsync(cancellationToken);
                 if (results.Status == DialogTurnStatus.Empty)
                 {
-                    var options = new PromptOptions {
+                    var options = new PromptOptions
+                    {
                         Prompt = new Activity { Type = ActivityTypes.Message, Text = "Enter a number." },
-                        RetryPrompt = new Activity {  Type = ActivityTypes.Message, Text = "You must enter a positive number less than 100." }
+                        RetryPrompt = new Activity { Type = ActivityTypes.Message, Text = "You must enter a positive number less than 100." },
                     };
                     await dc.PromptAsync("NumberPrompt", options, cancellationToken);
                 }
@@ -162,7 +165,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             .AssertReply("Bot received the number '64'.")
             .StartTestAsync();
         }
-        
+
         [TestMethod]
         public async Task FloatNumberPrompt()
         {
@@ -186,7 +189,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                 {
                     var options = new PromptOptions
                     {
-                        Prompt = new Activity { Type = ActivityTypes.Message, Text = "Enter a number." }
+                        Prompt = new Activity { Type = ActivityTypes.Message, Text = "Enter a number." },
                     };
                     await dc.PromptAsync("NumberPrompt", options, cancellationToken);
                 }
@@ -202,7 +205,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             .AssertReply("Bot received the number '3.14'.")
             .StartTestAsync();
         }
-        
+
         [TestMethod]
         public async Task LongNumberPrompt()
         {
@@ -226,7 +229,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                 {
                     var options = new PromptOptions
                     {
-                        Prompt = new Activity { Type = ActivityTypes.Message, Text = "Enter a number." }
+                        Prompt = new Activity { Type = ActivityTypes.Message, Text = "Enter a number." },
                     };
                     await dc.PromptAsync("NumberPrompt", options, cancellationToken);
                 }
@@ -242,7 +245,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             .AssertReply("Bot received the number '42'.")
             .StartTestAsync();
         }
-        
+
         [TestMethod]
         public async Task DoubleNumberPrompt()
         {
@@ -266,7 +269,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                 {
                     var options = new PromptOptions
                     {
-                        Prompt = new Activity { Type = ActivityTypes.Message, Text = "Enter a number." }
+                        Prompt = new Activity { Type = ActivityTypes.Message, Text = "Enter a number." },
                     };
                     await dc.PromptAsync("NumberPrompt", options);
                 }
@@ -306,7 +309,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                 {
                     var options = new PromptOptions
                     {
-                        Prompt = new Activity { Type = ActivityTypes.Message, Text = "Enter a number." }
+                        Prompt = new Activity { Type = ActivityTypes.Message, Text = "Enter a number." },
                     };
                     await dc.PromptAsync("NumberPrompt", options, cancellationToken);
                 }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/OAuthPromptTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/OAuthPromptTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
         [ExpectedException(typeof(ArgumentNullException))]
         public void OAuthPromptWithEmptyIdShouldFail()
         {
-            var emptyId = "";
+            var emptyId = string.Empty;
             var confirmPrompt = new OAuthPrompt(emptyId, new OAuthPromptSettings());
         }
 
@@ -62,10 +62,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
 
             await new TestFlow(adapter, botCallbackHandler)
             .Send("hello")
-            .AssertReply(activity => {
+            .AssertReply(activity =>
+            {
                 Assert.AreEqual(1, ((Activity)activity).Attachments.Count);
                 Assert.AreEqual(OAuthCard.ContentType, ((Activity)activity).Attachments[0].ContentType);
-                
+
                 // Prepare an EventActivity with a TokenResponse and send it to the botCallbackHandler
                 var eventActivity = CreateEventResponse(adapter, activity, connectionName, token);
                 var ctx = new TurnContext(adapter, (Activity)eventActivity);
@@ -116,7 +117,8 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
 
             await new TestFlow(adapter, botCallbackHandler)
             .Send("hello")
-            .AssertReply(activity => {
+            .AssertReply(activity =>
+            {
                 Assert.AreEqual(1, ((Activity)activity).Attachments.Count);
                 Assert.AreEqual(OAuthCard.ContentType, ((Activity)activity).Attachments[0].ContentType);
 
@@ -143,7 +145,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             eventActivity.Value = JObject.FromObject(new TokenResponse()
             {
                 ConnectionName = connectionName,
-                Token = token
+                Token = token,
             });
 
             return eventActivity;

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/PromptValidatorContextTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/PromptValidatorContextTests.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                 return Task.FromResult(true);
             }));
 
-            dialogs.Add(new WaterfallDialog("nameDialog", new WaterfallStep[]
+            var steps = new WaterfallStep[]
                     {
                         async (stepContext, cancellationToken) =>
                         {
@@ -38,9 +38,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                             var name = (string)stepContext.Result;
                             await stepContext.Context.SendActivityAsync(MessageFactory.Text($"{name} is a great name!"), cancellationToken);
                             return await stepContext.EndDialogAsync();
-                        }
-                    }
-                ));
+                        },
+                    };
+            dialogs.Add(new WaterfallDialog(
+                "nameDialog",
+                steps));
 
             await new TestFlow(adapter, async (turnContext, cancellationToken) =>
             {
@@ -85,10 +87,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                 {
                     await promptContext.Context.SendActivityAsync(MessageFactory.Text("Please send a name that is longer than 3 characters."), cancellationToken);
                 }
+
                 return false;
             }));
 
-            dialogs.Add(new WaterfallDialog("nameDialog", new WaterfallStep[]
+            var steps = new WaterfallStep[]
                     {
                         async (stepContext, cancellationToken) =>
                         {
@@ -99,9 +102,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                             var name = (string)stepContext.Result;
                             await stepContext.Context.SendActivityAsync(MessageFactory.Text($"{name} is a great name!"), cancellationToken);
                             return await stepContext.EndDialogAsync();
-                        }
-                    }
-                ));
+                        },
+                    };
+            dialogs.Add(new WaterfallDialog(
+                "nameDialog",
+                steps));
 
             await new TestFlow(adapter, async (turnContext, cancellationToken) =>
             {

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/TestUtilities.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/TestUtilities.cs
@@ -13,28 +13,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
 {
     public class TestUtilities
     {
-        public static TurnContext CreateEmptyContext()
-        {
-            var b = new TestAdapter();
-            var a = new Activity
-            {
-                Type = ActivityTypes.Message,
-                ChannelId = "EmptyContext",
-                From = new ChannelAccount
-                {
-                    Id = "empty@empty.context.org",
-                }, 
-                Conversation = new ConversationAccount()
-                {
-                    Id="213123123123"
-                }
-            };
-            var bc = new TurnContext(b, a);
-
-            return bc;
-        }
-
-        static Lazy<Dictionary<string, string>> environmentKeys = new Lazy<Dictionary<string, string>>(() =>
+        private static Lazy<Dictionary<string, string>> environmentKeys = new Lazy<Dictionary<string, string>>(() =>
         {
             try
             {
@@ -50,6 +29,28 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             }
         });
 
+        public static TurnContext CreateEmptyContext()
+        {
+            var b = new TestAdapter();
+            var a = new Activity
+            {
+                Type = ActivityTypes.Message,
+                ChannelId = "EmptyContext",
+                From = new ChannelAccount
+                {
+                    Id = "empty@empty.context.org",
+                },
+
+                Conversation = new ConversationAccount()
+                {
+                    Id = "213123123123",
+                },
+            };
+            var bc = new TurnContext(b, a);
+
+            return bc;
+        }
+
         public static string GetKey(string key)
         {
             if (!environmentKeys.Value.TryGetValue(key, out var value))
@@ -57,8 +58,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                 // fallback to environment variables
                 value = Environment.GetEnvironmentVariable(key);
                 if (string.IsNullOrWhiteSpace(value))
+                {
                     value = null;
+                }
             }
+
             return value;
         }
     }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/TextPromptTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/TextPromptTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
         [ExpectedException(typeof(ArgumentNullException))]
         public void TextPromptWithEmptyIdShouldFail()
         {
-            var emptyId = "";
+            var emptyId = string.Empty;
             var textPrompt = new TextPrompt(emptyId);
         }
 
@@ -24,7 +24,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
         [ExpectedException(typeof(ArgumentNullException))]
         public void TextPromptWithNullIdShouldFail()
         {
-            var nullId = "";
+            var nullId = string.Empty;
             nullId = null;
             var textPrompt = new TextPrompt(nullId);
         }
@@ -137,11 +137,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                 {
                     return Task.FromResult(true);
                 }
+
                 return Task.FromResult(false);
             };
             var textPrompt = new TextPrompt("TextPrompt", validator);
             dialogs.Add(textPrompt);
-        
+
             await new TestFlow(adapter, async (turnContext, cancellationToken) =>
             {
                 var dc = await dialogs.CreateContextAsync(turnContext, cancellationToken);
@@ -149,7 +150,8 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                 var results = await dc.ContinueDialogAsync(cancellationToken);
                 if (results.Status == DialogTurnStatus.Empty)
                 {
-                    var options = new PromptOptions {
+                    var options = new PromptOptions
+                    {
                         Prompt = new Activity { Type = ActivityTypes.Message, Text = "Enter some text." },
                         RetryPrompt = new Activity { Type = ActivityTypes.Message, Text = "Make sure the text is greater than three characters." },
                     };

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/WaterfallTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/WaterfallTests.cs
@@ -15,6 +15,42 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
     [TestClass]
     public class WaterfallTests
     {
+        public static WaterfallDialog Create_Waterfall3()
+        {
+            var steps = new WaterfallStep[]
+            {
+                Waterfall3_Step1,
+                Waterfall3_Step2,
+            };
+            return new WaterfallDialog(
+                "test-waterfall-a",
+                steps);
+        }
+
+        public static WaterfallDialog Create_Waterfall4()
+        {
+            var steps = new WaterfallStep[]
+            {
+                Waterfall4_Step1,
+                Waterfall4_Step2,
+            };
+            return new WaterfallDialog(
+                "test-waterfall-b",
+                steps);
+        }
+
+        public static WaterfallDialog Create_Waterfall5()
+        {
+            var steps = new WaterfallStep[]
+            {
+                Waterfall5_Step1,
+                Waterfall5_Step2,
+            };
+            return new WaterfallDialog(
+                "test-waterfall-c",
+                steps);
+        }
+
         [TestMethod]
         public async Task Waterfall()
         {
@@ -25,12 +61,27 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
 
             var dialogState = convoState.CreateProperty<DialogState>("dialogState");
             var dialogs = new DialogSet(dialogState);
-            dialogs.Add(new WaterfallDialog("test", new WaterfallStep[]
+            var steps = new WaterfallStep[]
             {
-                async (step, cancellationToken) => { await step.Context.SendActivityAsync("step1"); return Dialog.EndOfTurn; },
-                async (step, cancellationToken) => { await step.Context.SendActivityAsync("step2"); return Dialog.EndOfTurn; },
-                async (step, cancellationToken) => { await step.Context.SendActivityAsync("step3"); return Dialog.EndOfTurn; },
-            }));
+                async (step, cancellationToken) =>
+                {
+                    await step.Context.SendActivityAsync("step1");
+                    return Dialog.EndOfTurn;
+                },
+                async (step, cancellationToken) =>
+                {
+                    await step.Context.SendActivityAsync("step2");
+                    return Dialog.EndOfTurn;
+                },
+                async (step, cancellationToken) =>
+                {
+                    await step.Context.SendActivityAsync("step3");
+                    return Dialog.EndOfTurn;
+                },
+            };
+            dialogs.Add(new WaterfallDialog(
+                "test",
+                steps));
 
             await new TestFlow(adapter, async (turnContext, cancellationToken) =>
             {
@@ -60,12 +111,27 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
 
             var dialogState = convoState.CreateProperty<DialogState>("dialogState");
             var dialogs = new DialogSet(dialogState);
-            var waterfallDialog = new WaterfallDialog("test", new WaterfallStep[]
+            var steps = new WaterfallStep[]
             {
-                async (step, cancellationToken) => { await step.Context.SendActivityAsync("step1"); return Dialog.EndOfTurn; },
-                async (step, cancellationToken) => { await step.Context.SendActivityAsync("step2"); return Dialog.EndOfTurn; },
-                async (step, cancellationToken) => { await step.Context.SendActivityAsync("step3"); return Dialog.EndOfTurn; },
-            });
+                async (step, cancellationToken) =>
+                {
+                    await step.Context.SendActivityAsync("step1");
+                    return Dialog.EndOfTurn;
+                },
+                async (step, cancellationToken) =>
+                {
+                    await step.Context.SendActivityAsync("step2");
+                    return Dialog.EndOfTurn;
+                },
+                async (step, cancellationToken) =>
+                {
+                    await step.Context.SendActivityAsync("step3");
+                    return Dialog.EndOfTurn;
+                },
+            };
+            var waterfallDialog = new WaterfallDialog(
+                "test",
+                steps);
 
             dialogs.Add(waterfallDialog);
 
@@ -87,13 +153,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             .StartTestAsync();
         }
 
-
         [TestMethod]
         [ExpectedException(typeof(ArgumentNullException))]
         public void WaterfallWithStepsNull()
         {
             var waterfall = new WaterfallDialog("test");
-            waterfall.AddStep(null);            
+            waterfall.AddStep(null);
         }
 
         [TestMethod]
@@ -125,7 +190,6 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             .AssertReply("step3")
             .StartTestAsync();
         }
-
 
         [TestMethod]
         public async Task WaterfallPrompt()
@@ -170,50 +234,6 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             .AssertReply("Thanks for '64'")
             .AssertReply("step3")
             .StartTestAsync();
-        }
-
-        private static WaterfallDialog Create_Waterfall2()
-        {
-            return new WaterfallDialog("test-waterfall", new WaterfallStep[] {
-                Waterfall2_Step1,
-                Waterfall2_Step2,
-                Waterfall2_Step3
-            });
-        }
-
-        private static async Task<DialogTurnResult> Waterfall2_Step1(WaterfallStepContext stepContext, CancellationToken cancellationToken)
-        {
-            await stepContext.Context.SendActivityAsync("step1");
-            return await stepContext.PromptAsync("number", new PromptOptions
-            {
-                Prompt = MessageFactory.Text("Enter a number."),
-                RetryPrompt = MessageFactory.Text("It must be a number")
-            });
-        }
-        private static async Task<DialogTurnResult> Waterfall2_Step2(WaterfallStepContext stepContext, CancellationToken cancellationToken)
-        {
-            if (stepContext.Values != null)
-            {
-                var numberResult = (int)stepContext.Result;
-                await stepContext.Context.SendActivityAsync($"Thanks for '{numberResult}'");
-            }
-            await stepContext.Context.SendActivityAsync("step2");
-            return await stepContext.PromptAsync("number",
-                new PromptOptions
-                {
-                    Prompt = MessageFactory.Text("Enter a number."),
-                    RetryPrompt = MessageFactory.Text("It must be a number")
-                });
-        }
-        private static async Task<DialogTurnResult> Waterfall2_Step3(WaterfallStepContext stepContext, CancellationToken cancellationToken)
-        {
-            if (stepContext.Values != null)
-            {
-                var numberResult = (int)stepContext.Result;
-                await stepContext.Context.SendActivityAsync($"Thanks for '{numberResult}'");
-            }
-            await stepContext.Context.SendActivityAsync("step3");
-            return await stepContext.EndDialogAsync(new Dictionary<string, object> { { "Value", "All Done!" } });
         }
 
         [TestMethod]
@@ -262,18 +282,21 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
 
             var dialogs = new DialogSet(dialogState);
             dialogs.Add(new DateTimePrompt("dateTimePrompt", defaultLocale: Culture.English));
-            dialogs.Add(new WaterfallDialog("test-dateTimePrompt", new WaterfallStep[]
+            var steps = new WaterfallStep[]
             {
                 async (stepContext, cancellationToken) =>
                 {
-                    return await stepContext.PromptAsync("dateTimePrompt", new PromptOptions{ Prompt = new Activity { Text = "Provide a date", Type = ActivityTypes.Message }});
+                    return await stepContext.PromptAsync("dateTimePrompt", new PromptOptions { Prompt = new Activity { Text = "Provide a date", Type = ActivityTypes.Message } });
                 },
                 async (stepContext, cancellationToken) =>
                 {
                     Assert.IsNotNull(stepContext);
                     return await stepContext.EndDialogAsync();
-                }
-            }));
+                },
+            };
+            dialogs.Add(new WaterfallDialog(
+                "test-dateTimePrompt",
+                steps));
 
             var adapter = new TestAdapter()
                 .Use(new AutoSaveStateMiddleware(convoState));
@@ -299,27 +322,57 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             .StartTestAsync();
         }
 
-        public static WaterfallDialog Create_Waterfall3()
+        private static WaterfallDialog Create_Waterfall2()
         {
-            return new WaterfallDialog("test-waterfall-a", new WaterfallStep[] {
-                Waterfall3_Step1,
-                Waterfall3_Step2
-            });
+            var steps = new WaterfallStep[]
+                {
+                    Waterfall2_Step1,
+                    Waterfall2_Step2,
+                    Waterfall2_Step3,
+                };
+            return new WaterfallDialog(
+                "test-waterfall",
+                steps);
         }
-        public static WaterfallDialog Create_Waterfall4()
+
+        private static async Task<DialogTurnResult> Waterfall2_Step1(WaterfallStepContext stepContext, CancellationToken cancellationToken)
         {
-            return new WaterfallDialog("test-waterfall-b", new WaterfallStep[] {
-                Waterfall4_Step1,
-                Waterfall4_Step2
+            await stepContext.Context.SendActivityAsync("step1");
+            return await stepContext.PromptAsync("number", new PromptOptions
+            {
+                Prompt = MessageFactory.Text("Enter a number."),
+                RetryPrompt = MessageFactory.Text("It must be a number"),
             });
         }
 
-        public static WaterfallDialog Create_Waterfall5()
+        private static async Task<DialogTurnResult> Waterfall2_Step2(WaterfallStepContext stepContext, CancellationToken cancellationToken)
         {
-            return new WaterfallDialog("test-waterfall-c", new WaterfallStep[] {
-                Waterfall5_Step1,
-                Waterfall5_Step2
-            });
+            if (stepContext.Values != null)
+            {
+                var numberResult = (int)stepContext.Result;
+                await stepContext.Context.SendActivityAsync($"Thanks for '{numberResult}'");
+            }
+
+            await stepContext.Context.SendActivityAsync("step2");
+            return await stepContext.PromptAsync(
+                "number",
+                new PromptOptions
+                {
+                    Prompt = MessageFactory.Text("Enter a number."),
+                    RetryPrompt = MessageFactory.Text("It must be a number"),
+                });
+        }
+
+        private static async Task<DialogTurnResult> Waterfall2_Step3(WaterfallStepContext stepContext, CancellationToken cancellationToken)
+        {
+            if (stepContext.Values != null)
+            {
+                var numberResult = (int)stepContext.Result;
+                await stepContext.Context.SendActivityAsync($"Thanks for '{numberResult}'");
+            }
+
+            await stepContext.Context.SendActivityAsync("step3");
+            return await stepContext.EndDialogAsync(new Dictionary<string, object> { { "Value", "All Done!" } });
         }
 
         private static async Task<DialogTurnResult> Waterfall3_Step1(WaterfallStepContext stepContext, CancellationToken cancellationToken)
@@ -327,6 +380,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             await stepContext.Context.SendActivityAsync(MessageFactory.Text("step1"), cancellationToken);
             return await stepContext.BeginDialogAsync("test-waterfall-b", null, cancellationToken);
         }
+
         private static async Task<DialogTurnResult> Waterfall3_Step2(WaterfallStepContext stepContext, CancellationToken cancellationToken)
         {
             await stepContext.Context.SendActivityAsync(MessageFactory.Text("step2"), cancellationToken);
@@ -338,6 +392,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             await stepContext.Context.SendActivityAsync(MessageFactory.Text("step1.1"), cancellationToken);
             return Dialog.EndOfTurn;
         }
+
         private static async Task<DialogTurnResult> Waterfall4_Step2(WaterfallStepContext stepContext, CancellationToken cancellationToken)
         {
             await stepContext.Context.SendActivityAsync(MessageFactory.Text("step1.2"), cancellationToken);
@@ -349,39 +404,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             await stepContext.Context.SendActivityAsync(MessageFactory.Text("step2.1"), cancellationToken);
             return Dialog.EndOfTurn;
         }
+
         private static async Task<DialogTurnResult> Waterfall5_Step2(WaterfallStepContext stepContext, CancellationToken cancellationToken)
         {
             await stepContext.Context.SendActivityAsync(MessageFactory.Text("step2.2"), cancellationToken);
             return await stepContext.EndDialogAsync(cancellationToken);
         }
-
     }
-
-    public class MyWaterfallDialog : WaterfallDialog
-    {
-        public MyWaterfallDialog(string id)
-            : base(id)
-        {
-            AddStep(Waterfall2_Step1);
-            AddStep(Waterfall2_Step2);
-            AddStep(Waterfall2_Step3);
-        }
-
-        private static async Task<DialogTurnResult> Waterfall2_Step1(WaterfallStepContext stepContext, CancellationToken cancellationToken)
-        {
-            await stepContext.Context.SendActivityAsync("step1");
-            return Dialog.EndOfTurn; 
-        }
-        private static async Task<DialogTurnResult> Waterfall2_Step2(WaterfallStepContext stepContext, CancellationToken cancellationToken)
-        {
-            await stepContext.Context.SendActivityAsync("step2");
-            return Dialog.EndOfTurn;
-        }
-        private static async Task<DialogTurnResult> Waterfall2_Step3(WaterfallStepContext stepContext, CancellationToken cancellationToken)
-        {
-            await stepContext.Context.SendActivityAsync("step3");
-            return Dialog.EndOfTurn; 
-        }
-    }
-
 }


### PR DESCRIPTION
- Reorder parameters
- Remove trailing whitespace and add trailing commas
- Replace "" with string.Empy
- Fix spacing
