### PR TITLE
[Azure] Add test methods for DeleteAsync with partitionKey

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Azure/CosmosDbStorage.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/CosmosDbStorage.cs
@@ -131,6 +131,8 @@ namespace Microsoft.Bot.Builder.Azure
         /// <seealso cref="WriteAsync(IDictionary{string, object}, CancellationToken)"/>
         public async Task DeleteAsync(string[] keys, CancellationToken cancellationToken)
         {
+            RequestOptions options = null;
+
             if (keys == null)
             {
                 throw new ArgumentNullException(nameof(keys));
@@ -143,12 +145,19 @@ namespace Microsoft.Bot.Builder.Azure
 
             // Ensure Initialization has been run
             await InitializeAsync().ConfigureAwait(false);
-            var options = new RequestOptions() { PartitionKey = new PartitionKey(this._partitionKey) };
+
+            if (!string.IsNullOrEmpty(this._partitionKey))
+            {
+                options = new RequestOptions() { PartitionKey = new PartitionKey(this._partitionKey) };
+            }
 
             // Parallelize deletion
             var tasks = keys.Select(key =>
                 _client.DeleteDocumentAsync(
-                    UriFactory.CreateDocumentUri(_databaseId, _collectionId, CosmosDbKeyEscape.EscapeKey(key)),
+                    UriFactory.CreateDocumentUri(
+                        _databaseId,
+                        _collectionId,
+                        CosmosDbKeyEscape.EscapeKey(key)),
                     options,
                     cancellationToken: cancellationToken));
 

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/CosmosDbStorageTests.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/CosmosDbStorageTests.cs
@@ -410,7 +410,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         }
 
         [TestMethod]
-        public async Task DeleteDocumentFromSingleCollection()
+        public async Task DeleteAsyncFromSingleCollection()
         {
             string DocumentId = "UtteranceLog-001";
             string[] keys = { DocumentId };
@@ -434,7 +434,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         }
 
         [TestMethod]
-        public async Task DeleteDocumentFromPartitionedCollection()
+        public async Task DeleteAsyncFromPartitionedCollection()
         {
             /// The WriteAsync method receive a object as a parameter then encapsulate it in a object named "document"
             /// The partitionKeyPath must have the "document" value to properly route the values as partitionKey
@@ -465,8 +465,8 @@ namespace Microsoft.Bot.Builder.Azure.Tests
             Assert.IsTrue(result.IsCompletedSuccessfully);
         }
       
-        [TestMethod]
-        public async Task DeleteFromCosmosStorageWithoutPartitionKey()
+        [TestMethod] 
+        public async Task DeleteAsyncFromPartitionedCollectionWithoutPartitionKey()
         {
             /// The WriteAsync method receive a object as a parameter then encapsulate it in a object named "document"
             /// The partitionKeyPath must have the "document" value to properly route the values as partitionKey

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/CosmosDbStorageTests.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/CosmosDbStorageTests.cs
@@ -27,6 +27,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         private const string CosmosAuthKey = "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==";
         private const string CosmosDatabaseName = "test-db";
         private const string CosmosCollectionName = "bot-storage";
+        private const string CosmosDBPartitionKey = "UtteranceLog";
 
         private static string _emulatorPath = Environment.ExpandEnvironmentVariables(@"%ProgramFiles%\Azure Cosmos DB Emulator\CosmosDB.Emulator.exe");
         private const string _noEmulatorMessage = "This test requires CosmosDB Emulator! go to https://aka.ms/documentdb-emulator-docs to download and install.";
@@ -412,19 +413,27 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         {
             var storage = new CosmosDbStorage(new CosmosDbStorageOptions()
             {
-                PartitionKey = string.Empty,
+                PartitionKey = CosmosDBPartitionKey,
                 AuthKey = CosmosAuthKey,
                 CollectionId = CosmosCollectionName,
                 CosmosDBEndpoint = new Uri(CosmosServiceEndpoint),
                 DatabaseId = CosmosDatabaseName,
             });
 
-            await storage.DeleteAsync(new string[] { "foo" }, CancellationToken.None);
+            await storage.WriteAsync(new Dictionary<string, object>()
+            {
+                { CosmosDBPartitionKey, new object() }
+            }, CancellationToken.None);
+
+            string[] utteranceList = { "UtteranceLog" };
+
+            await storage.DeleteAsync(utteranceList, CancellationToken.None);
         }
 
         [TestMethod]
         public async Task DeleteFromCosmosStorageWithoutPartitionKey()
         {
+            // No PartitionKey
             var storage = new CosmosDbStorage(new CosmosDbStorageOptions()
             {
                 PartitionKey = string.Empty,
@@ -434,10 +443,14 @@ namespace Microsoft.Bot.Builder.Azure.Tests
                 DatabaseId = CosmosDatabaseName,
             });
 
-            string extStr = "PartitionKey value must be supplied for this operation";
-            Assert.ThrowsException<InvalidOperationException>(() => extStr);
+            string[] utteranceList = { "UtteranceLog" };
+            await storage.WriteAsync(new Dictionary<string, object>()
+            {
+                { CosmosDBPartitionKey, utteranceList }
+            }, CancellationToken.None);
 
-            await storage.DeleteAsync(new string[] { "foo" }, CancellationToken.None);
+            // Should throw
+            await Assert.ThrowsExceptionAsync<DocumentClientException>(async () => await storage.DeleteAsync(utteranceList, CancellationToken.None));
         }
 
         public bool CheckEmulator()

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/CosmosDbStorageTests.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/CosmosDbStorageTests.cs
@@ -407,6 +407,39 @@ namespace Microsoft.Bot.Builder.Azure.Tests
             }
         }
 
+        [TestMethod]
+        public async Task DeleteFromCosmosStorageWithPartitionKey()
+        {
+            var storage = new CosmosDbStorage(new CosmosDbStorageOptions()
+            {
+                PartitionKey = string.Empty,
+                AuthKey = CosmosAuthKey,
+                CollectionId = CosmosCollectionName,
+                CosmosDBEndpoint = new Uri(CosmosServiceEndpoint),
+                DatabaseId = CosmosDatabaseName,
+            });
+
+            await storage.DeleteAsync(new string[] { "foo" }, CancellationToken.None);
+        }
+
+        [TestMethod]
+        public async Task DeleteFromCosmosStorageWithoutPartitionKey()
+        {
+            var storage = new CosmosDbStorage(new CosmosDbStorageOptions()
+            {
+                PartitionKey = string.Empty,
+                AuthKey = CosmosAuthKey,
+                CollectionId = CosmosCollectionName,
+                CosmosDBEndpoint = new Uri(CosmosServiceEndpoint),
+                DatabaseId = CosmosDatabaseName,
+            });
+
+            string extStr = "PartitionKey value must be supplied for this operation";
+            Assert.ThrowsException<InvalidOperationException>(() => extStr);
+
+            await storage.DeleteAsync(new string[] { "foo" }, CancellationToken.None);
+        }
+
         public bool CheckEmulator()
         {
             if (!_hasEmulator.Value)

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/CosmosDbStorageTests.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/CosmosDbStorageTests.cs
@@ -195,14 +195,16 @@ namespace Microsoft.Bot.Builder.Azure.Tests
             var mock = new Mock<IDocumentClient>();
 
             mock.Setup(client => client.CreateDatabaseIfNotExistsAsync(It.IsAny<Database>(), It.IsAny<RequestOptions>()))
-                .ReturnsAsync(() => {
+                .ReturnsAsync(() =>
+                {
                     var database = new Database();
                     database.SetPropertyValue("SelfLink", "dummyDB_SelfLink");
                     return new ResourceResponse<Database>(database);
                 });
 
             mock.Setup(client => client.CreateDocumentCollectionIfNotExistsAsync(It.IsAny<Uri>(), It.IsAny<DocumentCollection>(), It.IsAny<RequestOptions>()))
-                .ReturnsAsync(() => {
+                .ReturnsAsync(() =>
+                {
                     var documentCollection = new DocumentCollection();
                     documentCollection.SetPropertyValue("SelfLink", "dummyDC_SelfLink");
                     return new ResourceResponse<DocumentCollection>(documentCollection);
@@ -412,20 +414,14 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         [TestMethod]
         public async Task DeleteAsyncFromSingleCollection()
         {
-            string DocumentId = "UtteranceLog-001";
-            string[] keys = { DocumentId };
-            var storage = new CosmosDbStorage(new CosmosDbStorageOptions()
-            {
-                AuthKey = CosmosAuthKey,
-                CollectionId = CosmosCollectionName,
-                CosmosDBEndpoint = new Uri(CosmosServiceEndpoint),
-                DatabaseId = CosmosDatabaseName,
-            });
+            string documentId = "UtteranceLog-001";
+            string[] keys = { documentId };
+            var storage = new CosmosDbStorage(CreateCosmosDbStorageOptions());
             var item = new StoreItem { MessageList = new string[] { "hi", "how are u" }, City = "Contoso" };
             var changes = new Dictionary<string, object>();
             {
-                changes.Add(DocumentId, item);
-            };
+                changes.Add(documentId, item);
+            }
 
             await storage.WriteAsync(changes, CancellationToken.None);
 
@@ -440,73 +436,49 @@ namespace Microsoft.Bot.Builder.Azure.Tests
             /// The partitionKeyPath must have the "document" value to properly route the values as partitionKey
             /// <seealso cref="WriteAsync(IDictionary{string, object}, CancellationToken)"/>
             string partitionKeyPath = "document/city";
-            string DocumentId = "UtteranceLog-001";
-            string[] keys = { DocumentId };
+            string documentId = "UtteranceLog-001";
+            string[] keys = { documentId };
 
-            await CreateCosmosDbWithPartitionedCollection(partitionKeyPath); 
+            await CreateCosmosDbWithPartitionedCollection(partitionKeyPath);
 
             // Connect to the comosDb created before
-            var storage = new CosmosDbStorage(new CosmosDbStorageOptions()
-            {
-                PartitionKey = "Contoso",
-                AuthKey = CosmosAuthKey,
-                CollectionId = CosmosCollectionName,
-                CosmosDBEndpoint = new Uri(CosmosServiceEndpoint),
-                DatabaseId = CosmosDatabaseName,
-            });
-            var item = new StoreItem { MessageList = new string[]{ "hi", "how are u" } , City = "Contoso" };
+            var storage = new CosmosDbStorage(CreateCosmosDbStorageOptions("Contoso"));
+            var item = new StoreItem { MessageList = new string[] { "hi", "how are u" }, City = "Contoso" };
             var changes = new Dictionary<string, object>();
             {
-                changes.Add(DocumentId, item);
-            };
+                changes.Add(documentId, item);
+            }
+
             await storage.WriteAsync(changes, CancellationToken.None);
 
             var result = await Task.WhenAny(storage.DeleteAsync(keys, CancellationToken.None)).ConfigureAwait(false);
             Assert.IsTrue(result.IsCompletedSuccessfully);
         }
-      
-        [TestMethod] 
+
+        [TestMethod]
         public async Task DeleteAsyncFromPartitionedCollectionWithoutPartitionKey()
         {
             /// The WriteAsync method receive a object as a parameter then encapsulate it in a object named "document"
             /// The partitionKeyPath must have the "document" value to properly route the values as partitionKey
             /// <seealso cref="WriteAsync(IDictionary{string, object}, CancellationToken)"/>
             string partitionKeyPath = "document/city";
-            string DocumentId = "UtteranceLog-001";
-            string[] keys = { DocumentId };
+            string documentId = "UtteranceLog-001";
+            string[] keys = { documentId };
 
             await CreateCosmosDbWithPartitionedCollection(partitionKeyPath);
 
             // Connect to the comosDb created before
-            var storage = new CosmosDbStorage(new CosmosDbStorageOptions()
-            {
-                PartitionKey = string.Empty,
-                AuthKey = CosmosAuthKey,
-                CollectionId = CosmosCollectionName,
-                CosmosDBEndpoint = new Uri(CosmosServiceEndpoint),
-                DatabaseId = CosmosDatabaseName,
-            });
+            var storage = new CosmosDbStorage(CreateCosmosDbStorageOptions());
             var item = new StoreItem { MessageList = new string[] { "hi", "how are u" }, City = "Contoso" };
             var changes = new Dictionary<string, object>();
             {
-                changes.Add(DocumentId, item);
-            };
+                changes.Add(documentId, item);
+            }
+
             await storage.WriteAsync(changes, CancellationToken.None);
 
             // Should throw InvalidOperationException: PartitionKey value must be supplied for this operation.
             await Assert.ThrowsExceptionAsync<InvalidOperationException>(async () => await storage.DeleteAsync(keys, CancellationToken.None));
-        }
-
-        private static async Task CreateCosmosDbWithPartitionedCollection(string partitionKey)
-        {
-            using (var client = new DocumentClient(new Uri(CosmosServiceEndpoint), CosmosAuthKey))
-            {
-                Database _database = await client.CreateDatabaseIfNotExistsAsync(new Database { Id = CosmosDatabaseName });
-                var partitionKeyDefinition = new PartitionKeyDefinition { Paths = new Collection<string> { $"/{partitionKey}" } };
-                var collectionDefinition = new DocumentCollection { Id = CosmosCollectionName, PartitionKey = partitionKeyDefinition };
-
-                await client.CreateDocumentCollectionIfNotExistsAsync(_database.SelfLink, collectionDefinition);
-            }
         }
 
         public bool CheckEmulator()
@@ -518,16 +490,40 @@ namespace Microsoft.Bot.Builder.Azure.Tests
 
             return _hasEmulator.Value;
         }
-    }
 
-    internal class StoreItem : IStoreItem
-    {
-        [JsonProperty(PropertyName = "messageList")]
-        public string[] MessageList { get; set; }
+        private static async Task CreateCosmosDbWithPartitionedCollection(string partitionKey)
+        {
+            using (var client = new DocumentClient(new Uri(CosmosServiceEndpoint), CosmosAuthKey))
+            {
+                Database database = await client.CreateDatabaseIfNotExistsAsync(new Database { Id = CosmosDatabaseName });
+                var partitionKeyDefinition = new PartitionKeyDefinition { Paths = new Collection<string> { $"/{partitionKey}" } };
+                var collectionDefinition = new DocumentCollection { Id = CosmosCollectionName, PartitionKey = partitionKeyDefinition };
 
-        [JsonProperty(PropertyName = "city")]
-        public string City { get; set; }
+                await client.CreateDocumentCollectionIfNotExistsAsync(database.SelfLink, collectionDefinition);
+            }
+        }
 
-        public string ETag { get; set; }
+        private static CosmosDbStorageOptions CreateCosmosDbStorageOptions(string partitionKey = "")
+        {
+            return new CosmosDbStorageOptions()
+            {
+                PartitionKey = partitionKey,
+                AuthKey = CosmosAuthKey,
+                CollectionId = CosmosCollectionName,
+                CosmosDBEndpoint = new Uri(CosmosServiceEndpoint),
+                DatabaseId = CosmosDatabaseName,
+            };
+        }
+
+        internal class StoreItem : IStoreItem
+        {
+            [JsonProperty(PropertyName = "messageList")]
+            public string[] MessageList { get; set; }
+
+            [JsonProperty(PropertyName = "city")]
+            public string City { get; set; }
+
+            public string ETag { get; set; }
+        }
     }
 }

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/CosmosDbStorageTests.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/CosmosDbStorageTests.cs
@@ -30,6 +30,10 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         private const string CosmosDatabaseName = "test-db";
         private const string CosmosCollectionName = "bot-storage";
 
+        // Variables used to test delete cases
+        private const string DocumentId = "UtteranceLog-001";
+        private readonly StoreItem ItemToTest = new StoreItem { MessageList = new string[] { "hi", "how are u" }, City = "Contoso" };
+
         private static string _emulatorPath = Environment.ExpandEnvironmentVariables(@"%ProgramFiles%\Azure Cosmos DB Emulator\CosmosDB.Emulator.exe");
         private const string _noEmulatorMessage = "This test requires CosmosDB Emulator! go to https://aka.ms/documentdb-emulator-docs to download and install.";
         private static Lazy<bool> _hasEmulator = new Lazy<bool>(() =>
@@ -414,18 +418,13 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         [TestMethod]
         public async Task DeleteAsyncFromSingleCollection()
         {
-            string documentId = "UtteranceLog-001";
-            string[] keys = { documentId };
             var storage = new CosmosDbStorage(CreateCosmosDbStorageOptions());
-            var item = new StoreItem { MessageList = new string[] { "hi", "how are u" }, City = "Contoso" };
             var changes = new Dictionary<string, object>();
-            {
-                changes.Add(documentId, item);
-            }
+            changes.Add(DocumentId, ItemToTest);
 
             await storage.WriteAsync(changes, CancellationToken.None);
 
-            var result = await Task.WhenAny(storage.DeleteAsync(keys, CancellationToken.None)).ConfigureAwait(false);
+            var result = await Task.WhenAny(storage.DeleteAsync(new string[] { DocumentId }, CancellationToken.None)).ConfigureAwait(false);
             Assert.IsTrue(result.IsCompletedSuccessfully);
         }
 
@@ -436,8 +435,6 @@ namespace Microsoft.Bot.Builder.Azure.Tests
             /// The partitionKeyPath must have the "document" value to properly route the values as partitionKey
             /// <seealso cref="WriteAsync(IDictionary{string, object}, CancellationToken)"/>
             string partitionKeyPath = "document/city";
-            string documentId = "UtteranceLog-001";
-            string[] keys = { documentId };
 
             await CreateCosmosDbWithPartitionedCollection(partitionKeyPath);
 
@@ -445,13 +442,11 @@ namespace Microsoft.Bot.Builder.Azure.Tests
             var storage = new CosmosDbStorage(CreateCosmosDbStorageOptions("Contoso"));
             var item = new StoreItem { MessageList = new string[] { "hi", "how are u" }, City = "Contoso" };
             var changes = new Dictionary<string, object>();
-            {
-                changes.Add(documentId, item);
-            }
+            changes.Add(DocumentId, ItemToTest);
 
             await storage.WriteAsync(changes, CancellationToken.None);
 
-            var result = await Task.WhenAny(storage.DeleteAsync(keys, CancellationToken.None)).ConfigureAwait(false);
+            var result = await Task.WhenAny(storage.DeleteAsync(new string[] { DocumentId }, CancellationToken.None)).ConfigureAwait(false);
             Assert.IsTrue(result.IsCompletedSuccessfully);
         }
 
@@ -462,23 +457,18 @@ namespace Microsoft.Bot.Builder.Azure.Tests
             /// The partitionKeyPath must have the "document" value to properly route the values as partitionKey
             /// <seealso cref="WriteAsync(IDictionary{string, object}, CancellationToken)"/>
             string partitionKeyPath = "document/city";
-            string documentId = "UtteranceLog-001";
-            string[] keys = { documentId };
 
             await CreateCosmosDbWithPartitionedCollection(partitionKeyPath);
 
             // Connect to the comosDb created before
             var storage = new CosmosDbStorage(CreateCosmosDbStorageOptions());
-            var item = new StoreItem { MessageList = new string[] { "hi", "how are u" }, City = "Contoso" };
             var changes = new Dictionary<string, object>();
-            {
-                changes.Add(documentId, item);
-            }
+            changes.Add(DocumentId, ItemToTest);
 
             await storage.WriteAsync(changes, CancellationToken.None);
 
             // Should throw InvalidOperationException: PartitionKey value must be supplied for this operation.
-            await Assert.ThrowsExceptionAsync<InvalidOperationException>(async () => await storage.DeleteAsync(keys, CancellationToken.None));
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(async () => await storage.DeleteAsync(new string[] { DocumentId }, CancellationToken.None));
         }
 
         public bool CheckEmulator()

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/CosmosDbStorageTests.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/CosmosDbStorageTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.IO;
 using System.Threading;
@@ -14,6 +15,7 @@ using Microsoft.Bot.Builder.Dialogs;
 using Microsoft.Bot.Builder.Tests;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
+using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Builder.Azure.Tests
 {
@@ -27,7 +29,6 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         private const string CosmosAuthKey = "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==";
         private const string CosmosDatabaseName = "test-db";
         private const string CosmosCollectionName = "bot-storage";
-        private const string CosmosDBPartitionKey = "UtteranceLog";
 
         private static string _emulatorPath = Environment.ExpandEnvironmentVariables(@"%ProgramFiles%\Azure Cosmos DB Emulator\CosmosDB.Emulator.exe");
         private const string _noEmulatorMessage = "This test requires CosmosDB Emulator! go to https://aka.ms/documentdb-emulator-docs to download and install.";
@@ -409,31 +410,74 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         }
 
         [TestMethod]
-        public async Task DeleteFromCosmosStorageWithPartitionKey()
+        public async Task DeleteDocumentFromSingleCollection()
         {
+            string DocumentId = "UtteranceLog-001";
+            string[] keys = { DocumentId };
             var storage = new CosmosDbStorage(new CosmosDbStorageOptions()
             {
-                PartitionKey = CosmosDBPartitionKey,
                 AuthKey = CosmosAuthKey,
                 CollectionId = CosmosCollectionName,
                 CosmosDBEndpoint = new Uri(CosmosServiceEndpoint),
                 DatabaseId = CosmosDatabaseName,
             });
-
-            await storage.WriteAsync(new Dictionary<string, object>()
+            var item = new StoreItem { MessageList = new string[] { "hi", "how are u" }, City = "Contoso" };
+            var changes = new Dictionary<string, object>();
             {
-                { CosmosDBPartitionKey, new object() }
-            }, CancellationToken.None);
+                changes.Add(DocumentId, item);
+            };
 
-            string[] utteranceList = { "UtteranceLog" };
+            await storage.WriteAsync(changes, CancellationToken.None);
 
-            await storage.DeleteAsync(utteranceList, CancellationToken.None);
+            var result = await Task.WhenAny(storage.DeleteAsync(keys, CancellationToken.None)).ConfigureAwait(false);
+            Assert.IsTrue(result.IsCompletedSuccessfully);
         }
 
         [TestMethod]
+        public async Task DeleteDocumentFromPartitionedCollection()
+        {
+            /// The WriteAsync method receive a object as a parameter then encapsulate it in a object named "document"
+            /// The partitionKeyPath must have the "document" value to properly route the values as partitionKey
+            /// <seealso cref="WriteAsync(IDictionary{string, object}, CancellationToken)"/>
+            string partitionKeyPath = "document/city";
+            string DocumentId = "UtteranceLog-001";
+            string[] keys = { DocumentId };
+
+            await CreateCosmosDbWithPartitionedCollection(partitionKeyPath); 
+
+            // Connect to the comosDb created before
+            var storage = new CosmosDbStorage(new CosmosDbStorageOptions()
+            {
+                PartitionKey = "Contoso",
+                AuthKey = CosmosAuthKey,
+                CollectionId = CosmosCollectionName,
+                CosmosDBEndpoint = new Uri(CosmosServiceEndpoint),
+                DatabaseId = CosmosDatabaseName,
+            });
+            var item = new StoreItem { MessageList = new string[]{ "hi", "how are u" } , City = "Contoso" };
+            var changes = new Dictionary<string, object>();
+            {
+                changes.Add(DocumentId, item);
+            };
+            await storage.WriteAsync(changes, CancellationToken.None);
+
+            var result = await Task.WhenAny(storage.DeleteAsync(keys, CancellationToken.None)).ConfigureAwait(false);
+            Assert.IsTrue(result.IsCompletedSuccessfully);
+        }
+      
+        [TestMethod]
         public async Task DeleteFromCosmosStorageWithoutPartitionKey()
         {
-            // No PartitionKey
+            /// The WriteAsync method receive a object as a parameter then encapsulate it in a object named "document"
+            /// The partitionKeyPath must have the "document" value to properly route the values as partitionKey
+            /// <seealso cref="WriteAsync(IDictionary{string, object}, CancellationToken)"/>
+            string partitionKeyPath = "document/city";
+            string DocumentId = "UtteranceLog-001";
+            string[] keys = { DocumentId };
+
+            await CreateCosmosDbWithPartitionedCollection(partitionKeyPath);
+
+            // Connect to the comosDb created before
             var storage = new CosmosDbStorage(new CosmosDbStorageOptions()
             {
                 PartitionKey = string.Empty,
@@ -442,15 +486,27 @@ namespace Microsoft.Bot.Builder.Azure.Tests
                 CosmosDBEndpoint = new Uri(CosmosServiceEndpoint),
                 DatabaseId = CosmosDatabaseName,
             });
-
-            string[] utteranceList = { "UtteranceLog" };
-            await storage.WriteAsync(new Dictionary<string, object>()
+            var item = new StoreItem { MessageList = new string[] { "hi", "how are u" }, City = "Contoso" };
+            var changes = new Dictionary<string, object>();
             {
-                { CosmosDBPartitionKey, utteranceList }
-            }, CancellationToken.None);
+                changes.Add(DocumentId, item);
+            };
+            await storage.WriteAsync(changes, CancellationToken.None);
 
-            // Should throw
-            await Assert.ThrowsExceptionAsync<DocumentClientException>(async () => await storage.DeleteAsync(utteranceList, CancellationToken.None));
+            // Should throw InvalidOperationException: PartitionKey value must be supplied for this operation.
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(async () => await storage.DeleteAsync(keys, CancellationToken.None));
+        }
+
+        private static async Task CreateCosmosDbWithPartitionedCollection(string partitionKey)
+        {
+            using (var client = new DocumentClient(new Uri(CosmosServiceEndpoint), CosmosAuthKey))
+            {
+                Database _database = await client.CreateDatabaseIfNotExistsAsync(new Database { Id = CosmosDatabaseName });
+                var partitionKeyDefinition = new PartitionKeyDefinition { Paths = new Collection<string> { $"/{partitionKey}" } };
+                var collectionDefinition = new DocumentCollection { Id = CosmosCollectionName, PartitionKey = partitionKeyDefinition };
+
+                await client.CreateDocumentCollectionIfNotExistsAsync(_database.SelfLink, collectionDefinition);
+            }
         }
 
         public bool CheckEmulator()
@@ -462,5 +518,16 @@ namespace Microsoft.Bot.Builder.Azure.Tests
 
             return _hasEmulator.Value;
         }
+    }
+
+    internal class StoreItem : IStoreItem
+    {
+        [JsonProperty(PropertyName = "messageList")]
+        public string[] MessageList { get; set; }
+
+        [JsonProperty(PropertyName = "city")]
+        public string City { get; set; }
+
+        public string ETag { get; set; }
     }
 }


### PR DESCRIPTION
### Description
We added the tests cases for the DeleteAsync method update.

### Changes made
Add **DeleteAsyncFromSingleCollection**
To test the actual behavior of the method. 

Add **DeleteAsyncFromPartitionedCollection** 
To test the behavior against a partitioned collection (passing a partition key as a parameter)

Add **DeleteAsyncFromPartitionedCollectionWithoutPartitionKey** 
To test the behavior against a partitioned collection (passing an empty partition key as a parameter)

#### Testing
![image](https://user-images.githubusercontent.com/37461749/54945283-3ba32a80-4f14-11e9-9724-c82ce8e8fc39.png)