### PR TITLE
Fix response.id assignation in SlackAdapter class

### DIFF
--- a/Botkit/Microsoft.BotKit.Adapters.Slack/SlackAdapter.cs
+++ b/Botkit/Microsoft.BotKit.Adapters.Slack/SlackAdapter.cs
@@ -1,4 +1,4 @@
-// Copyright(c) Microsoft Corporation.All rights reserved.
+﻿// Copyright(c) Microsoft Corporation.All rights reserved.
 // Licensed under the MIT License.
 
 using Microsoft.Rest.Serialization;
@@ -251,7 +251,7 @@ namespace Microsoft.BotKit.Adapters.Slack
                         {
                             ResourceResponse response = new ResourceResponse() //{ id = result.Id, activityId = result.Ts, conversation = new { Id = result.Channel } };
                             {
-                                Id = (result as dynamic).Id
+                                Id = (result as dynamic).ts
                             };
                             responses.Add(response as ResourceResponse);
                         }


### PR DESCRIPTION
## Proposed changes

Based on the work in PR #106, we fixed the assignation of the response id in _SendActivitiesAsync_ method.

``` CSharp
if (result.ok)
{
      ResourceResponse response = new ResourceResponse() 
      {
             Id = (result as dynamic).ts
      };
```