### PR TITLE
[Botkit] Refactor PostMessageAsync method

### DIFF
--- a/Botkit/Microsoft.BotKit.Adapters.Slack/SlackAdapter.cs
+++ b/Botkit/Microsoft.BotKit.Adapters.Slack/SlackAdapter.cs
@@ -246,22 +246,18 @@ namespace Microsoft.BotKit.Adapters.Slack
 
                         var client = new WebClient();
 
-                        if (message.Ephemeral != null)
-                        {
-                            var response = client.UploadValues("https://slack.com/api/chat.postEphemeral", "POST", data);
-                            responseInString = JsonConvert.DeserializeObject<SlackResponse>(Encoding.UTF8.GetString(response));
-                        }
-                        else
-                        {
-                            var response = client.UploadValues("https://slack.com/api/chat.postMessage", "POST", data);
-                            responseInString = JsonConvert.DeserializeObject<SlackResponse>(Encoding.UTF8.GetString(response));
-                        }
+                        string url = message.Ephemeral != null
+                            ? "https://slack.com/api/chat.postEphemeral"
+                            : "https://slack.com/api/chat.postMessage";
 
-                        if (responseInString.ok)
+                        var response = client.UploadValues(url, "POST", data);
+                        responseInString = JsonConvert.DeserializeObject<SlackResponse>(Encoding.UTF8.GetString(response));
+
+                        if (responseInString.Ok)
                         {
                             ResourceResponse rgResponse = new ResourceResponse() // { id = result.ts, activityId = result.ts, conversation = new { Id = result.Channel } };
                             {
-                                Id = responseInString.ts,
+                                Id = responseInString.TS,
                             };
                             responses.Add(rgResponse as ResourceResponse);
                         }

--- a/Botkit/Microsoft.BotKit.Adapters.Slack/SlackAdapter.cs
+++ b/Botkit/Microsoft.BotKit.Adapters.Slack/SlackAdapter.cs
@@ -13,6 +13,8 @@ using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Bot.Schema;
 using Newtonsoft.Json;
+using System.Collections.Specialized;
+using System.Net;
 
 namespace Microsoft.BotKit.Adapters.Slack
 {
@@ -234,24 +236,34 @@ namespace Microsoft.BotKit.Adapters.Slack
                     try
                     {
                         SlackTaskClient slack = await this.GetAPIAsync(turnContext.Activity);
-                        Response result;
+                        SlackResponse responseInString;
+
+                        var data = new NameValueCollection();
+                        data["token"] = this.options.BotToken;
+                        data["channel"] = message.channel;
+                        data["text"] = message.text;
+                        data["thread_ts"] = message.ThreadTS;
+
+                        var client = new WebClient();
 
                         if (message.Ephemeral != null)
                         {
-                            result = await slack.PostEphemeralMessageAsync(message.channel, message.text, message.user);
+                            var response = client.UploadValues("https://slack.com/api/chat.postEphemeral", "POST", data);
+                            responseInString = JsonConvert.DeserializeObject<SlackResponse>(Encoding.UTF8.GetString(response));
                         }
                         else
                         {
-                            result = await slack.PostMessageAsync(message.channel, message.text);
+                            var response = client.UploadValues("https://slack.com/api/chat.postMessage", "POST", data);
+                            responseInString = JsonConvert.DeserializeObject<SlackResponse>(Encoding.UTF8.GetString(response));
                         }
 
-                        if (result.ok)
+                        if (responseInString.ok)
                         {
-                            ResourceResponse response = new ResourceResponse() // { id = result.ts, activityId = result.ts, conversation = new { Id = result.Channel } };
+                            ResourceResponse rgResponse = new ResourceResponse() // { id = result.ts, activityId = result.ts, conversation = new { Id = result.Channel } };
                             {
-                                Id = (result as dynamic).ts,
+                                Id = responseInString.ts,
                             };
-                            responses.Add(response as ResourceResponse);
+                            responses.Add(rgResponse as ResourceResponse);
                         }
                     }
                     catch (Exception ex)

--- a/Botkit/Microsoft.BotKit.Adapters.Slack/SlackMessage.cs
+++ b/Botkit/Microsoft.BotKit.Adapters.Slack/SlackMessage.cs
@@ -1,0 +1,16 @@
+﻿// Copyright(c) Microsoft Corporation.All rights reserved.
+// Licensed under the MIT License.
+
+namespace Microsoft.BotKit.Adapters.Slack
+{
+    public class SlackMessage
+    {
+        public string type;
+        public string subtype;
+        public string text;
+        public string ts;
+        public string username;
+        public string bot_id;
+        public string thread_ts;
+    }
+}

--- a/Botkit/Microsoft.BotKit.Adapters.Slack/SlackMessage.cs
+++ b/Botkit/Microsoft.BotKit.Adapters.Slack/SlackMessage.cs
@@ -5,12 +5,18 @@ namespace Microsoft.BotKit.Adapters.Slack
 {
     public class SlackMessage
     {
-        public string type;
-        public string subtype;
-        public string text;
-        public string ts;
-        public string username;
-        public string bot_id;
-        public string thread_ts;
+        public string Type;
+
+        public string Subtype;
+
+        public string Text;
+
+        public string TS;
+
+        public string Username;
+
+        public string BotID;
+
+        public string ThreadTS;
     }
 }

--- a/Botkit/Microsoft.BotKit.Adapters.Slack/SlackResponse.cs
+++ b/Botkit/Microsoft.BotKit.Adapters.Slack/SlackResponse.cs
@@ -5,9 +5,12 @@ namespace Microsoft.BotKit.Adapters.Slack
 {
     public class SlackResponse
     {
-        public bool ok;
-        public string channel;
-        public string ts;
-        public SlackMessage message;
+        public bool Ok;
+
+        public string Channel;
+
+        public string TS;
+
+        public SlackMessage Message;
     }
 }

--- a/Botkit/Microsoft.BotKit.Adapters.Slack/SlackResponse.cs
+++ b/Botkit/Microsoft.BotKit.Adapters.Slack/SlackResponse.cs
@@ -1,0 +1,13 @@
+﻿// Copyright(c) Microsoft Corporation.All rights reserved.
+// Licensed under the MIT License.
+
+namespace Microsoft.BotKit.Adapters.Slack
+{
+    public class SlackResponse
+    {
+        public bool ok;
+        public string channel;
+        public string ts;
+        public SlackMessage message;
+    }
+}


### PR DESCRIPTION
## Proposed changes

- Replaced _PostMessageAsync_ and _PostEphemeralMessageAsync_ methods of _Inumedia Slack_ library with _PostMessage_ and _PostEphemeral_ methods of _**Slack API**_ to fix the issue related to the bot not answering in threads.
- Add two auxiliary classes to handle Slack Response.

_The previous methods weren't considering the **thread_ts** field that was needed to reply a message in the corresponding thread._