### PR TITLE
[Botkit] Fix warning in BotkitSlackMessage and IBotkitHandler classes

### DIFF
--- a/libraries/Microsoft.BotKit/Core/BotkitSlackMessage.cs
+++ b/libraries/Microsoft.BotKit/Core/BotkitSlackMessage.cs
@@ -1,29 +1,102 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
-using System.Text;
 using Microsoft.Bot.Schema;
 
 namespace Microsoft.BotKit.Core
 {
+    /// <summary>
+    /// Defines the expected form of a message or event object being handled by Botkit.
+    /// </summary>
     public class BotkitSlackMessage : IBotkitMessage
     {
+        /// <summary>
+        /// Gets or sets the type of event, in most cases defined by the messaging channel or adapter.
+        /// </summary>
         public string Type { get; set; }
+
+        /// <summary>
+        /// Gets or sets the text of the message.
+        /// </summary>
         public string Text { get; set; }
+
+        /// <summary>
+        /// Gets or sets any value field received from the platform.
+        /// </summary>
         public string Value { get; set; }
+
+        /// <summary>
+        /// Gets or sets the unique identifier of user who sent the message.
+        /// </summary>
         public string User { get; set; }
+
+        /// <summary>
+        /// Gets or sets the unique identifier of the room/channel/space in which the message was sent.
+        /// </summary>
         public string Channel { get; set; }
+
+        /// <summary>
+        /// Gets or sets the AttachmentLayout.
+        /// </summary>
         public string AttachmentLayout { get; set; }
+
+        /// <summary>
+        /// Gets or sets the speak indicator for the message.
+        /// </summary>
         public string Speak { get; set; }
+
+        /// <summary>
+        /// Gets or sets the input Hint for the message.
+        /// </summary>
         public string InputHint { get; set; }
+
+        /// <summary>
+        /// Gets or sets the summary for the message.
+        /// </summary>
         public string Summary { get; set; }
+
+        /// <summary>
+        /// Gets or sets the text format for the message.
+        /// </summary>
         public string TextFormat { get; set; }
+
+        /// <summary>
+        /// Gets or sets the importance of the message.
+        /// </summary>
         public string Importance { get; set; }
+
+        /// <summary>
+        /// Gets or sets the delivery mode for the message.
+        /// </summary>
         public string DeliveryMode { get; set; }
+
+        /// <summary>
+        /// Gets or sets the ChannelData object.
+        /// </summary>
         public object ChannelData { get; set; }
+
+        /// <summary>
+        /// Gets or sets the expiration date of the message.
+        /// </summary>
         public DateTimeOffset Expiration { get; set; }
+
+        /// <summary>
+        /// Gets or sets the Reference object.
+        /// </summary>
         public ConversationReference Reference { get; set; }
+
+        /// <summary>
+        /// Gets or sets the activity representing the incoming message.
+        /// </summary>
         public Activity IncomingMessage { get; set; }
+
+        /// <summary>
+        /// Gets or sets a list of attachments.
+        /// </summary>
         public IList<Attachment> Attachments { get; set; }
+
+        /// <summary>
+        /// Gets or sets the suggested actions.
+        /// </summary>
         public SuggestedActions SuggestedActions { get; set; }
     }
 }

--- a/libraries/Microsoft.BotKit/Core/IBotkitHandler.cs
+++ b/libraries/Microsoft.BotKit/Core/IBotkitHandler.cs
@@ -1,12 +1,21 @@
-// Copyright(c) Microsoft Corporation.All rights reserved.
+﻿// Copyright(c) Microsoft Corporation.All rights reserved.
 // Licensed under the MIT License.
 
 using System.Threading.Tasks;
 
 namespace Microsoft.BotKit.Core
 {
+    /// <summary>
+    /// Interface for implementing a BotkitHandler.
+    /// </summary>
     public interface IBotkitHandler
     {
+        /// <summary>
+        /// Instanciates a BotkitHandler.
+        /// </summary>
+        /// <param name="botWorker">An instance of BotWorker class.</param>
+        /// <param name="botkitMessage">A botkit message.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         Task<object> Handler(BotWorker botWorker, IBotkitMessage botkitMessage);
     }
 }


### PR DESCRIPTION
## Proposed changes

Fix StyleCop warnings in _**BotkitSlackMessage**_ and **_IBotkitHandler_** classes.
- Add documentation for classes, methods, and properties.
- Remove unnecessary using statements.