### PR TITLE
[StyleCop] Fix warnings on AdapterError and BotKitBotFrameworkAdapter

### DIFF
--- a/libraries/Microsoft.BotKit.Adapters.Slack/AdapterError.cs
+++ b/libraries/Microsoft.BotKit.Adapters.Slack/AdapterError.cs
@@ -5,11 +5,12 @@ namespace Microsoft.BotKit.Adapters.Slack
 {
     public class AdapterError
     {
-        public string Name;
-        public string Error;
-
         public AdapterError()
         {
         }
+
+        public string Name { get; private set; }
+
+        public string Error { get; private set; }
     }
 }

--- a/libraries/Microsoft.BotKit/BotkitBotFrameworkAdapter.cs
+++ b/libraries/Microsoft.BotKit/BotkitBotFrameworkAdapter.cs
@@ -1,44 +1,47 @@
-// Copyright(c) Microsoft Corporation.All rights reserved.
+﻿// Copyright(c) Microsoft Corporation.All rights reserved.
 // Licensed under the MIT License.
 
-using Microsoft.Bot.Builder;
-using Microsoft.Bot.Connector;
-using Microsoft.Bot.Connector.Authentication;
-using Newtonsoft.Json;
 using System;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading.Tasks;
+using Microsoft.Bot.Builder;
+using Microsoft.Bot.Connector;
+using Microsoft.Bot.Connector.Authentication;
+using Newtonsoft.Json;
 
 namespace Microsoft.BotKit
 {
     public class BotkitBotFrameworkAdapter : BotFrameworkAdapter
     {
-        protected readonly MicrosoftAppCredentials _credentials;
-
         /// <summary>
+        /// Initializes a new instance of the <see cref="BotkitBotFrameworkAdapter"/> class.
         /// This class extends the BotFrameworkAdapter with a few additional features to support Microsoft Teams.
         /// </summary>
-        /// <param name="options"></param>
-        /// <param name="credentials"></param>
-        public BotkitBotFrameworkAdapter(ICredentialProvider options, MicrosoftAppCredentials credentials) : base(options)
+        /// <param name="options">options of the BotkitBotFrameworkAdapter.</param>
+        /// <param name="credentials">credentials of the BotkitBotFrameworkAdapter.</param>
+        public BotkitBotFrameworkAdapter(ICredentialProvider options, MicrosoftAppCredentials credentials)
+            : base(options)
         {
-            _credentials = credentials;
+            Credentials = credentials;
         }
+
+        protected MicrosoftAppCredentials Credentials { get; }
 
         /// <summary>
         /// Get the list of channels in a MS Teams team.
         /// Can only be called with a TurnContext that originated in a team conversation - 1:1 conversations happen _outside a team_ and thus do not contain the required information to call this API.
         /// </summary>
-        /// <param name="turnContext">A TurnContext object representing a message or event from a user in Teams</param>
-        /// <returns>An array of channels in the format [{name: string, id: string}]</returns>
+        /// <param name="turnContext">A TurnContext object representing a message or event from a user in Teams.</param>
+        /// <returns>An array of channels in the format [{name: string, id: string}].</returns>
         public async Task<Channel[]> GetChannels(TurnContext turnContext)
         {
-            if(turnContext.Activity.ChannelData != null && (turnContext.Activity.ChannelData as dynamic).team != null) //TO-DO: replace 'as dynamic'
+            // TO-DO: replace 'as dynamic'
+            if (turnContext.Activity.ChannelData != null && (turnContext.Activity.ChannelData as dynamic).team != null)
             {
-                var token = await _credentials.GetTokenAsync(true);
+                var token = await Credentials.GetTokenAsync(true);
 
-                var uri = $"{ turnContext.Activity.ServiceUrl }v3/teams/{ (turnContext.Activity.ChannelData as dynamic).team.id }/conversations/"; //TO-DO: replace 'as dynamic'
+                var uri = $"{turnContext.Activity.ServiceUrl}v3/teams/{(turnContext.Activity.ChannelData as dynamic).team.id}/conversations/"; // TO-DO: replace 'as dynamic'
 
                 return await RequestUrl(token, uri);
             }
@@ -52,19 +55,19 @@ namespace Microsoft.BotKit
         {
             using (var client = new HttpClient())
             {
-                client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue($"Bearer { token }");
+                client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue($"Bearer {token}");
 
                 HttpResponseMessage response = await client.GetAsync(uri);
 
                 var result = await response.Content.ReadAsStringAsync();
                 var json = JsonConvert.DeserializeObject(result);
-                var conversations = (json as dynamic).conversations; //TO-DO: replace 'as dynamic'
+                var conversations = (json as dynamic).conversations; // TO-DO: replace 'as dynamic'
 
                 if (conversations != null && conversations.count > 0)
                 {
-                    foreach(var c in conversations)
+                    foreach (var c in conversations)
                     {
-                        if(c.name is null)
+                        if (c.name is null)
                         {
                             c.name = "General";
                         }
@@ -81,18 +84,20 @@ namespace Microsoft.BotKit
         /// Allows for mocking of the connector client in unit tests.
         /// </summary>
         /// <param name="serviceUrl">Clients service url.</param>
+        /// <returns>ConnectorClient type.</returns>
         protected ConnectorClient CreateConnectorClient(string serviceUrl)
         {
-            return new ConnectorClient(new Uri(serviceUrl), _credentials);
+            return new ConnectorClient(new Uri(serviceUrl), Credentials);
         }
 
         /// <summary>
         /// Allows for mocking of the OAuth API Client in unit tests.
         /// </summary>
         /// <param name="serviceUrl">Clients service url.</param>
-        protected OAuthClient CreateTokenApiClient(string serviceUrl) 
+        /// <returns>OAuthClient type.</returns>
+        protected OAuthClient CreateTokenApiClient(string serviceUrl)
         {
-            return new OAuthClient(new Uri(serviceUrl), _credentials);
+            return new OAuthClient(new Uri(serviceUrl), Credentials);
         }
     }
 }


### PR DESCRIPTION
Fix warnings on **AdapterError**.cs and **BotKitBotFrameworkAdapter**.cs files.

### **Changes made**
- Resolve privacy issue
- Add black line
- Constructor not follow a prop
- Order using directives alphabetically by namespace
- Constructor documentation 
- Constructor initializer line
- Add spaces into sentences
- Add return type to Documentation
- Add final period to Documentation
- Remove final space into starting/closing brace 
- Remove trailing whitespace 
- Change property’s name to upper case
