### PR TITLE
[StyleCop] Fix remaining warnings in BotWorker, DialogData, DialogElement and CMSConfiguration class

### DIFF
--- a/libraries/Microsoft.BotKit.Adapters.Slack/DialogData.cs
+++ b/libraries/Microsoft.BotKit.Adapters.Slack/DialogData.cs
@@ -1,4 +1,4 @@
-// Copyright(c) Microsoft Corporation.All rights reserved.
+﻿// Copyright(c) Microsoft Corporation.All rights reserved.
 // Licensed under the MIT License.
 
 using System.Collections.Generic;
@@ -28,31 +28,37 @@ namespace Microsoft.BotKit.Adapters.Slack
         /// <summary>
         /// Gets or Sets the tittle of the dialog.
         /// </summary>
+        /// <value>The tittle of the dialog.</value>
         public string Title { get; set; }
 
         /// <summary>
         /// Gets or Sets the callback Id of the dialog.
         /// </summary>
+        /// <value>The callback id of the dialog.</value>
         public string CallbackId { get; set; }
 
         /// <summary>
         /// Gets or Sets the submit label of the dialog.
         /// </summary>
+        /// <value>The submit label of the dialog.</value>
         public string SubmitLabel { get; set; }
 
         /// <summary>
         /// Gets or Sets a list of elements contained by the dialog.
         /// </summary>
+        /// <value>The elements of the dialog.</value>
         public List<DialogElement> Elements { get; set; }
 
         /// <summary>
         /// Gets or Sets the state of the dialog.
         /// </summary>
+        /// <value>The state of the dialog.</value>
         public string State { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether the dialog should notify on cancel or not.
         /// </summary>
+        /// <value>The notifyOnCancel indicator of the dialog.</value>
         public bool NotifyOnCancel { get; set; }
     }
 }

--- a/libraries/Microsoft.BotKit.Adapters.Slack/DialogElement.cs
+++ b/libraries/Microsoft.BotKit.Adapters.Slack/DialogElement.cs
@@ -1,4 +1,4 @@
-// Copyright(c) Microsoft Corporation.All rights reserved.
+﻿// Copyright(c) Microsoft Corporation.All rights reserved.
 // Licensed under the MIT License.
 
 using System.Collections.Generic;
@@ -13,36 +13,43 @@ namespace Microsoft.BotKit.Adapters.Slack
         /// <summary>
         /// Gets or Sets the label for the dialog element.
         /// </summary>
+        /// <value>The label for the element.</value>
         public string Label { get; set; }
 
         /// <summary>
         /// Gets or Sets the name for the dialog element.
         /// </summary>
+        /// <value>The name for the element.</value>
         public string Name { get; set; }
 
         /// <summary>
         /// Gets or Sets the value for the dialog element.
         /// </summary>
+        /// <value>The value for the element.</value>
         public string Value { get; set; }
 
         /// <summary>
         /// Gets or Sets the pair of values for an option List in the dialog element.
         /// </summary>
+        /// <value>The option list for the element.</value>
         public Dictionary<string, string> OptionList { get; set; }
 
         /// <summary>
         /// Gets or Sets options for the dialog element.
         /// </summary>
+        /// <value>The options for the element.</value>
         public ISlackAdapterOptions Options { get; set; }
 
         /// <summary>
         /// Gets or Sets the type for the dialog element.
         /// </summary>
+        /// <value>The type for the element.</value>
         public string Type { get; set; }
 
         /// <summary>
         /// Gets or Sets the subtype for the dialog element.
         /// </summary>
+        /// <value>The subtype for the element.</value>
         public string Subtype { get; set; }
     }
 }

--- a/libraries/Microsoft.BotKit/BotWorker.cs
+++ b/libraries/Microsoft.BotKit/BotWorker.cs
@@ -19,8 +19,6 @@ namespace Microsoft.BotKit
     /// </summary>
     public class BotWorker
     {
-        public BotWorkerConfiguration Config { get; private set; }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="BotWorker"/> class.
         /// Create a new BotWorker instance. Do not call this directly - instead, use controller.spawn().
@@ -34,8 +32,15 @@ namespace Microsoft.BotKit
         }
 
         /// <summary>
+        /// Gets the configuration for BotWorker.
+        /// </summary>
+        /// <value>The botkit Configuration.</value>
+        public BotWorkerConfiguration Config { get; private set; }
+
+        /// <summary>
         /// Gets Controller of BotWorker.
         /// </summary>
+        /// <value>The botkit Controller.</value>
         public Botkit Controller { get; }
 
         /// <summary>

--- a/libraries/Microsoft.BotKit/BotWorker.cs
+++ b/libraries/Microsoft.BotKit/BotWorker.cs
@@ -34,13 +34,13 @@ namespace Microsoft.BotKit
         /// <summary>
         /// Gets the configuration for BotWorker.
         /// </summary>
-        /// <value>The botkit Configuration.</value>
+        /// <value>The BotWorker Configuration.</value>
         public BotWorkerConfiguration Config { get; private set; }
 
         /// <summary>
         /// Gets Controller of BotWorker.
         /// </summary>
-        /// <value>The botkit Controller.</value>
+        /// <value>The BotWorker Controller.</value>
         public Botkit Controller { get; }
 
         /// <summary>

--- a/libraries/Microsoft.BotKit/CMS/CMSConfiguration.cs
+++ b/libraries/Microsoft.BotKit/CMS/CMSConfiguration.cs
@@ -1,4 +1,4 @@
-// Copyright(c) Microsoft Corporation.All rights reserved.
+﻿// Copyright(c) Microsoft Corporation.All rights reserved.
 // Licensed under the MIT License.
 
 namespace Microsoft.BotKit.CMS


### PR DESCRIPTION
## Proposed changes
- Save files with encoding UTF-8 with BOM.
- Add value documentation to properties.
- Reorder constructor and properties.