### PR TITLE
[Botkit][Twilio] Remove 'as dynamic' casting

### DIFF
--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Twilio/TwilioAdapter.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Twilio/TwilioAdapter.cs
@@ -109,6 +109,12 @@ namespace Microsoft.Bot.Builder.Adapters.Twilio
 
                 TwilioEvent twilioEvent = JsonConvert.DeserializeObject<TwilioEvent>(jsonBody);
 
+                if (Convert.ToInt32(twilioEvent.NumMedia) > 0)
+                {
+                    // specify a different event type
+                    twilioEvent.EventType = "picture_message";
+                }
+
                 var activity = new Activity()
                 {
                     Id = twilioEvent.MessageSid,
@@ -126,17 +132,10 @@ namespace Microsoft.Bot.Builder.Adapters.Twilio
                     {
                         Id = twilioEvent.To,
                     },
-                    Text = (twilioEvent as dynamic).Body,
+                    Text = twilioEvent.Body,
                     ChannelData = twilioEvent,
                     Type = ActivityTypes.Message,
                 };
-
-                // Detect attachments
-                if (Convert.ToInt32(twilioEvent.NumMedia) > 0)
-                {
-                    // specify a different event type for Botkit
-                    (activity.ChannelData as dynamic).botkitEventType = "picture_message";
-                }
 
                 // create a conversation reference
                 using (var context = new TurnContext(this, activity))
@@ -186,9 +185,9 @@ namespace Microsoft.Bot.Builder.Adapters.Twilio
         {
             var mediaUrls = new List<Uri>();
 
-            if ((activity.ChannelData as dynamic)?.mediaURL != null)
+            if ((activity.ChannelData as TwilioEvent)?.MediaUrl != null)
             {
-                mediaUrls.Add(new Uri((activity.ChannelData as dynamic).mediaURL));
+                mediaUrls.Add(new Uri(((TwilioEvent)activity.ChannelData).MediaUrl));
             }
 
             var messageOptions = new CreateMessageOptions(activity.Conversation.Id)

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Twilio/TwilioEvent.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Twilio/TwilioEvent.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Bot.Builder.Adapters.Twilio
 
         public string NumMedia { get; set; }
 
+        public string MediaUrl { get; set; }
+
         public string ToCity { get; set; }
 
         public string FromZip { get; set; }
@@ -40,5 +42,7 @@ namespace Microsoft.Bot.Builder.Adapters.Twilio
         public string From { get; set; }
 
         public string ApiVersion { get; set; }
+
+        public string EventType { get; set; }
     }
 }


### PR DESCRIPTION
## Proposed Changes
- Replaced the `as dynamic` casting with casting to TwilioEvent class.
- Add two properties to TwilioEvent class needed in the adapter. The _EventType_ and _MediaUrl_ properties.
