### PR TITLE
[TwilioAdapter] Create test for successful constructor of TwilioAdapter

### DIFF
--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Twilio.Tests/TwilioAdapterTests.cs
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Twilio.Tests/TwilioAdapterTests.cs
@@ -61,9 +61,7 @@ namespace Microsoft.Bot.Builder.Adapters.Twilio.Tests
                 AuthToken = "Test",
             };
 
-            var adapter = new TwilioAdapter(options);
-
-            Assert.NotNull(adapter);
+            Assert.NotNull(new TwilioAdapter(options));
         }
 
         private class MockTwilioOptions : ITwilioAdapterOptions

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Twilio.Tests/TwilioAdapterTests.cs
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Twilio.Tests/TwilioAdapterTests.cs
@@ -51,6 +51,21 @@ namespace Microsoft.Bot.Builder.Adapters.Twilio.Tests
             Assert.Throws<Exception>(() => { new TwilioAdapter(options); });
         }
 
+        [Fact]
+        public void Constructor_WithArguments_Succeeds()
+        {
+            ITwilioAdapterOptions options = new MockTwilioOptions
+            {
+                TwilioNumber = "Test",
+                AccountSid = "Test",
+                AuthToken = "Test",
+            };
+
+            var adapter = new TwilioAdapter(options);
+
+            Assert.NotNull(adapter);
+        }
+
         private class MockTwilioOptions : ITwilioAdapterOptions
         {
             public string TwilioNumber { get; set; }

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Twilio.Tests/TwilioAdapterTests.cs
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Twilio.Tests/TwilioAdapterTests.cs
@@ -1,5 +1,7 @@
-﻿using System;
-using Microsoft.Bot.Builder.Adapters.Twilio;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
 using Xunit;
 
 namespace Microsoft.Bot.Builder.Adapters.Twilio.Tests


### PR DESCRIPTION
- Add test `Constructor_WithArguments_Succeeds ` to validate the creation of the TwilioAdapter when ITwilioAdapterOptions has its properties