### PR TITLE
[TwilioAdapter] Add support for Twilio Conversations API

### DIFF
--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Twilio/TwilioHelper.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Twilio/TwilioHelper.cs
@@ -86,11 +86,11 @@ namespace Microsoft.Bot.Builder.Adapters.Twilio
                 ChannelId = Channels.Twilio,
                 Conversation = new ConversationAccount()
                 {
-                    Id = twilioMessage.From,
+                    Id = twilioMessage.From ?? twilioMessage.Author,
                 },
                 From = new ChannelAccount()
                 {
-                    Id = twilioMessage.From,
+                    Id = twilioMessage.From ?? twilioMessage.Author,
                 },
                 Recipient = new ChannelAccount()
                 {

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Twilio/TwilioMessage.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Twilio/TwilioMessage.cs
@@ -12,6 +12,14 @@ namespace Microsoft.Bot.Builder.Adapters.Twilio
     public class TwilioMessage
     {
         /// <summary>
+        /// Gets or sets the Author of the message.
+        /// </summary>
+        /// <value>
+        /// The Author of the message.
+        /// </value>
+        public string Author { get; set; }
+
+        /// <summary>
         /// Gets or sets the receiver's country.
         /// </summary>
         /// <value>The receiver's country. E.g. "US".</value>

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Twilio/TwilioMessage.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Twilio/TwilioMessage.cs
@@ -14,9 +14,7 @@ namespace Microsoft.Bot.Builder.Adapters.Twilio
         /// <summary>
         /// Gets or sets the Author of the message.
         /// </summary>
-        /// <value>
-        /// The Author of the message.
-        /// </value>
+        /// <value>The Author of the message.</value>
         public string Author { get; set; }
 
         /// <summary>


### PR DESCRIPTION
## Description
Added support for handling the message format when using Twilio's [Conversation API](https://www.twilio.com/docs/conversations)

## Details
When using the Conversation API the received payload differs from the format used for [standard SMS sending and receiving](https://www.twilio.com/docs/sms/api/message-resource#message-properties), with the structure of the message varying between the different events ([link](https://www.twilio.com/docs/conversations/conversations-webhooks)). 
Among other changes, the sender's phone number is stored in the **Author** field instead of **From**. This change adds support for both properties.

**Modified classes:**
* TwilioHelper.cs
* TwilioMessage.cs