### PR TITLE
[WebEx Adapter] Make several refactor improvements

### DIFF
--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/IWebexAdapterOptions.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/IWebexAdapterOptions.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
         string Secret { get; set; }
 
         /// <summary>
-        /// Gets or sets the root URL of your bot application.  Something like 'https://mybot.com/'.
+        /// Gets or sets the root URL of your bot application. Something like 'https://mybot.com/'.
         /// </summary>
         /// <value>the root URL of your bot application.</value>
         string PublicAddress { get; set; }

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/Microsoft.Bot.Builder.Adapters.Webex.csproj
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/Microsoft.Bot.Builder.Adapters.Webex.csproj
@@ -9,7 +9,6 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <RootNamespace>Microsoft.BotBuilder.Adapters.Webex</RootNamespace>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU' ">

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexAdapter.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexAdapter.cs
@@ -31,34 +31,29 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
         public WebexAdapter(IWebexAdapterOptions config)
             : base()
         {
-            _config = config;
-
-            if (_config.AccessToken != null)
-            {
-                _api = TeamsAPI.CreateVersion1Client(config.AccessToken);
-
-                if (_api == null)
-                {
-                    throw new Exception("Could not create the Webex Teams API client");
-                }
-            }
-            else
+            if (string.IsNullOrWhiteSpace(_config.AccessToken))
             {
                 throw new Exception("AccessToken required to create controller");
             }
 
-            if (_config.PublicAddress != null)
-            {
-                var endpoint = new Uri(_config.PublicAddress);
-
-                _config.PublicAddress = !string.IsNullOrWhiteSpace(endpoint.Host)
-                                        ? _config.PublicAddress = endpoint.Host
-                                        : throw new Exception("Could not determine hostname of public address");
-            }
-            else
+            if (string.IsNullOrWhiteSpace(_config.PublicAddress))
             {
                 throw new Exception("PublicAddress parameter required to receive webhooks");
             }
+
+            _config = config;
+            _api = TeamsAPI.CreateVersion1Client(config.AccessToken);
+
+            if (_api == null)
+            {
+                throw new Exception("Could not create the Webex Teams API client");
+            }
+
+            var endpoint = new Uri(_config.PublicAddress);
+
+            _config.PublicAddress = !string.IsNullOrWhiteSpace(endpoint.Host)
+                ? _config.PublicAddress = endpoint.Host
+                : throw new Exception("Could not determine hostname of public address");
         }
 
         /// <summary>

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexAdapter.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexAdapter.cs
@@ -176,7 +176,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
         /// </summary>
         /// <param name="reference">A <see cref="ConversationReference"/> to be applied to future messages.</param>
         /// <param name="logic">A bot logic function that will perform continuing action.</param>
-        /// <param name="cancellationToken">A cancellation token for the task</param>
+        /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public async Task ContinueConversationAsync(ConversationReference reference, BotCallbackHandler logic, CancellationToken cancellationToken)
         {
@@ -186,7 +186,6 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
             {
                 await RunPipelineAsync(context, logic, cancellationToken).ConfigureAwait(false);
             }
-
         }
 
         /// <summary>

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexAdapter.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexAdapter.cs
@@ -322,14 +322,12 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
 
             if (decryptedMessage.HasHtml)
             {
-                var pattern = new Regex("^(<p>)?<spark-mention .*?data-object-id=\"" + Identity.Id + "\".*?>.*?</spark-mention>");
+                var pattern = new Regex($"^(<p>)?<spark-mention .*?data-object-id=\"{Identity.Id}\".*?>.*?</spark-mention>");
                 if (!decryptedMessage.Html.Equals(pattern))
                 {
-                    var encodedId = Identity.Id;
-
                     // this should look like ciscospark://us/PEOPLE/<id string>
-                    var match = Regex.Match(encodedId, "/ciscospark://.*/(.*)/im");
-                    pattern = new Regex("^(<p>)?<spark-mention .*?data-object-id=\"" + match.Captures[1] + "\".*?>.*?</spark-mention>");
+                    var match = Regex.Match(Identity.Id, "/ciscospark://.*/(.*)/im");
+                    pattern = new Regex($"^(<p>)?<spark-mention .*?data-object-id=\"{match.Captures[1]}\".*?>.*?</spark-mention>");
                 }
 
                 var action = decryptedMessage.Html.Replace(pattern.ToString(), string.Empty);

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexAdapter.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexAdapter.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
             {
                 var endpoint = new Uri(_config.PublicAddress);
 
-                if (endpoint.Host != null)
+                if (string.IsNullOrWhiteSpace(endpoint.Host))
                 {
                     _config.PublicAddress = endpoint.Host;
                 }
@@ -151,10 +151,6 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
                     TeamsResult<Message> webexResponse = await _api.CreateDirectMessageAsync(personIDorEmail, text);
                     var response = new ResourceResponse(webexResponse.Data.Id);
                     responses.Add(response);
-                }
-                else
-                {
-                    // not type message
                 }
             }
 

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexAdapter.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexAdapter.cs
@@ -122,17 +122,22 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
             var responses = new List<ResourceResponse>();
             foreach (var activity in activities)
             {
-                if (!activity.Type.Equals(ActivityTypes.Message))
+                if (activity.Type != ActivityTypes.Message)
                 {
                     continue;
                 }
 
                 // transform activity into the webex message format
-                var personIDorEmail = ((activity.ChannelData as dynamic)?.toPersonEmail != null) ? (activity.ChannelData as dynamic).toPersonEmail : activity.Recipient.Id;
-                var text = (activity.ChannelData != null) ? (activity.ChannelData as dynamic).markdown : activity.Text;
+                var personIDorEmail = (activity.ChannelData as dynamic)?.toPersonEmail != null
+                                    ? (activity.ChannelData as dynamic).toPersonEmail
+                                    : activity.Recipient.Id;
+
+                var text = activity.ChannelData != null
+                            ? (activity.ChannelData as dynamic).markdown
+                            : activity.Text;
+
                 TeamsResult<Message> webexResponse = await _api.CreateDirectMessageAsync(personIDorEmail, text);
-                var response = new ResourceResponse(webexResponse.Data.Id);
-                responses.Add(response);
+                responses.Add(new ResourceResponse(webexResponse.Data.Id));
             }
 
             return responses.ToArray();

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexAdapter.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexAdapter.cs
@@ -176,14 +176,17 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
         /// </summary>
         /// <param name="reference">A <see cref="ConversationReference"/> to be applied to future messages.</param>
         /// <param name="logic">A bot logic function that will perform continuing action.</param>
+        /// <param name="cancellationToken">A cancellation token for the task</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task ContinueConversationAsync(ConversationReference reference, BotCallbackHandler logic)
+        public async Task ContinueConversationAsync(ConversationReference reference, BotCallbackHandler logic, CancellationToken cancellationToken)
         {
             var request = reference.GetContinuationActivity().ApplyConversationReference(reference, true);
 
-            var context = new TurnContext(this, request);
+            using (var context = new TurnContext(this, request))
+            {
+                await RunPipelineAsync(context, logic, cancellationToken).ConfigureAwait(false);
+            }
 
-            await RunPipelineAsync(context, logic, default(CancellationToken)).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexAdapter.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexAdapter.cs
@@ -227,6 +227,13 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
             }
         }
 
+        /// <summary>
+        /// Validates the local secret against the one obtained from the request header.
+        /// </summary>
+        /// <param name="secret">The local stored secret.</param>
+        /// <param name="request">The <see cref="HttpRequest"/> with the signature.</param>
+        /// <param name="json">The serialized payload to be use for comparison.</param>
+        /// <returns>The result of the comparison between the signature in the request and hashed json.</returns>
         private static bool ValidateSignature(string secret, HttpRequest request, string json)
         {
             var signature = request.Headers.ContainsKey("x-spark-signature")
@@ -242,6 +249,11 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
             }
         }
 
+        /// <summary>
+        /// Creates a <see cref="Activity"/> using the body of a request.
+        /// </summary>
+        /// <param name="payload">The payload obtained from the body of the request.</param>
+        /// <returns>An <see cref="Activity"/> object.</returns>
         private Activity PayloadToActivity(dynamic payload)
         {
             var activity = new Activity
@@ -270,6 +282,11 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
             return activity;
         }
 
+        /// <summary>
+        /// Converts a decrypted <see cref="Message"/> into an <see cref="Activity"/>.
+        /// </summary>
+        /// <param name="payload">The payload obtained from the body of the request.</param>
+        /// <returns>An <see cref="Activity"/> object.</returns>
         private async Task<Activity> DecryptedMessageToActivityAsync(dynamic payload)
         {
             Message decryptedMessage = (await _api.GetMessageAsync(payload.data.id.ToString())).GetData();

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexAdapter.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexAdapter.cs
@@ -19,11 +19,6 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
 {
     public class WebexAdapter : BotAdapter
     {
-        /// <summary>
-        /// Name used by Botkit plugin loader.
-        /// </summary>
-        public const string Name = "Webex Adapter";
-
         private readonly IWebexAdapterOptions _config;
 
         private readonly TeamsAPIClient _api;

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexAdapter.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexAdapter.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public async Task GetIdentityAsync()
         {
-            await _api.GetMeAsync().ContinueWith((task) => { Identity = task.Result.Data; });
+            await _api.GetMeAsync().ContinueWith(task => { Identity = task.Result.Data; }).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -67,13 +67,13 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public async Task ResetWebhookSubscriptions()
         {
-            await _api.ListWebhooksAsync().ContinueWith(async (task) =>
+            await _api.ListWebhooksAsync().ContinueWith(async task =>
             {
                 for (int i = 0; i < task.Result.Data.ItemCount; i++)
                 {
-                    await _api.DeleteWebhookAsync(task.Result.Data.Items[i]);
+                    await _api.DeleteWebhookAsync(task.Result.Data.Items[i]).ConfigureAwait(false);
                 }
-            });
+            }).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -101,13 +101,13 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
 
                 if (hookId != null)
                 {
-                    await _api.UpdateWebhookAsync(hookId, webHookName, new Uri(hookUrl), _config.Secret);
+                    await _api.UpdateWebhookAsync(hookId, webHookName, new Uri(hookUrl), _config.Secret).ConfigureAwait(false);
                 }
                 else
                 {
-                    await _api.CreateWebhookAsync(webHookName, new Uri(hookUrl), EventResource.All, EventType.All, null, _config.Secret);
+                    await _api.CreateWebhookAsync(webHookName, new Uri(hookUrl), EventResource.All, EventType.All, null, _config.Secret).ConfigureAwait(false);
                 }
-            });
+            }).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -147,7 +147,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
         public override async Task<ResourceResponse> UpdateActivityAsync(ITurnContext turnContext, Activity activity, CancellationToken cancellationToken)
         {
             // Webex adapter does not support updateActivity.
-            return await Task.FromException<ResourceResponse>(new NotImplementedException("Webex adapter does not support updateActivity."));
+            return await Task.FromException<ResourceResponse>(new NotImplementedException("Webex adapter does not support updateActivity.")).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -161,7 +161,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
         {
             if (reference.ActivityId != null)
             {
-                await _api.DeleteMessageAsync(reference.ActivityId, default(CancellationToken));
+                await _api.DeleteMessageAsync(reference.ActivityId, default(CancellationToken)).ConfigureAwait(false);
             }
         }
 
@@ -177,7 +177,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
 
             var context = new TurnContext(this, request);
 
-            await RunPipelineAsync(context, logic, default(CancellationToken));
+            await RunPipelineAsync(context, logic, default(CancellationToken)).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -191,7 +191,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
         public async Task ProcessAsync(HttpRequest request, HttpResponse response, IBot bot, CancellationToken cancellationToken = default(CancellationToken))
         {
             response.StatusCode = 200;
-            await response.WriteAsync(string.Empty);
+            await response.WriteAsync(string.Empty).ConfigureAwait(false);
 
             var bodyStream = new StreamReader(request.Body);
             dynamic payload = JsonConvert.DeserializeObject(bodyStream.ReadToEnd());
@@ -280,7 +280,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
 
                 var context = new TurnContext(this, activity);
 
-                await RunPipelineAsync(context, bot.OnTurnAsync, default(CancellationToken));
+                await RunPipelineAsync(context, bot.OnTurnAsync, default(CancellationToken)).ConfigureAwait(false);
             }
             else
             {
@@ -309,7 +309,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
 
                 var context = new TurnContext(this, activity);
 
-                await RunPipelineAsync(context, bot.OnTurnAsync, default(CancellationToken));
+                await RunPipelineAsync(context, bot.OnTurnAsync, default(CancellationToken)).ConfigureAwait(false);
             }
         }
     }

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexAdapter.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexAdapter.cs
@@ -51,14 +51,9 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
             {
                 var endpoint = new Uri(_config.PublicAddress);
 
-                if (string.IsNullOrWhiteSpace(endpoint.Host))
-                {
-                    _config.PublicAddress = endpoint.Host;
-                }
-                else
-                {
-                    throw new Exception("Could not determine hostname of public address");
-                }
+                _config.PublicAddress = !string.IsNullOrWhiteSpace(endpoint.Host)
+                                        ? _config.PublicAddress = endpoint.Host
+                                        : throw new Exception("Could not determine hostname of public address");
             }
             else
             {

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexAdapter.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexAdapter.cs
@@ -165,9 +165,9 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public override async Task DeleteActivityAsync(ITurnContext turnContext, ConversationReference reference, CancellationToken cancellationToken)
         {
-            if (reference.ActivityId != null)
+            if (!string.IsNullOrWhiteSpace(reference.ActivityId))
             {
-                await _api.DeleteMessageAsync(reference.ActivityId, default(CancellationToken)).ConfigureAwait(false);
+                await _api.DeleteMessageAsync(reference.ActivityId, cancellationToken).ConfigureAwait(false);
             }
         }
 

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexAdapter.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexAdapter.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
         {
             await _api.ListWebhooksAsync().ContinueWith(async task =>
             {
-                for (int i = 0; i < task.Result.Data.ItemCount; i++)
+                for (var i = 0; i < task.Result.Data.ItemCount; i++)
                 {
                     await _api.DeleteWebhookAsync(task.Result.Data.Items[i]).ConfigureAwait(false);
                 }
@@ -119,7 +119,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public override async Task<ResourceResponse[]> SendActivitiesAsync(ITurnContext turnContext, Activity[] activities, CancellationToken cancellationToken)
         {
-            List<ResourceResponse> responses = new List<ResourceResponse>();
+            var responses = new List<ResourceResponse>();
             for (int i = 0; i < activities.Length; i++)
             {
                 var activity = activities[i];
@@ -206,7 +206,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
                 {
                     var hashArray = hmac.ComputeHash(Encoding.UTF8.GetBytes(json));
 
-                    string hash = BitConverter.ToString(hashArray).Replace("-", string.Empty).ToLower();
+                    var hash = BitConverter.ToString(hashArray).Replace("-", string.Empty).ToLower();
 
                     if (!string.Equals(signature, hash))
                     {
@@ -257,7 +257,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
                         var encodedId = Identity.Id;
 
                         // this should look like ciscospark://us/PEOPLE/<id string>
-                        Match match = Regex.Match(encodedId, "/ciscospark://.*/(.*)/im");
+                        var match = Regex.Match(encodedId, "/ciscospark://.*/(.*)/im");
                         pattern = new Regex("^(<p>)?<spark-mention .*?data-object-id=\"" + match.Captures[1] + "\".*?>.*?</spark-mention>");
                     }
 

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexAdapter.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexAdapter.cs
@@ -120,18 +120,19 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
         public override async Task<ResourceResponse[]> SendActivitiesAsync(ITurnContext turnContext, Activity[] activities, CancellationToken cancellationToken)
         {
             var responses = new List<ResourceResponse>();
-            for (int i = 0; i < activities.Length; i++)
+            foreach (var activity in activities)
             {
-                var activity = activities[i];
-                if (activity.Type.Equals(ActivityTypes.Message))
+                if (!activity.Type.Equals(ActivityTypes.Message))
                 {
-                    // transform activity into the webex message format
-                    var personIDorEmail = ((activity.ChannelData as dynamic)?.toPersonEmail != null) ? (activity.ChannelData as dynamic).toPersonEmail : activity.Recipient.Id;
-                    var text = (activity.ChannelData != null) ? (activity.ChannelData as dynamic).markdown : activity.Text;
-                    TeamsResult<Message> webexResponse = await _api.CreateDirectMessageAsync(personIDorEmail, text);
-                    var response = new ResourceResponse(webexResponse.Data.Id);
-                    responses.Add(response);
+                    continue;
                 }
+
+                // transform activity into the webex message format
+                var personIDorEmail = ((activity.ChannelData as dynamic)?.toPersonEmail != null) ? (activity.ChannelData as dynamic).toPersonEmail : activity.Recipient.Id;
+                var text = (activity.ChannelData != null) ? (activity.ChannelData as dynamic).markdown : activity.Text;
+                TeamsResult<Message> webexResponse = await _api.CreateDirectMessageAsync(personIDorEmail, text);
+                var response = new ResourceResponse(webexResponse.Data.Id);
+                responses.Add(response);
             }
 
             return responses.ToArray();

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexAdapter.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexAdapter.cs
@@ -49,11 +49,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
                 throw new Exception("Could not create the Webex Teams API client");
             }
 
-            var endpoint = new Uri(_config.PublicAddress);
-
-            _config.PublicAddress = !string.IsNullOrWhiteSpace(endpoint.Host)
-                ? _config.PublicAddress = endpoint.Host
-                : throw new Exception("Could not determine hostname of public address");
+            _config.PublicAddress = new Uri(_config.PublicAddress).Host;
         }
 
         /// <summary>

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexAdapter.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexAdapter.cs
@@ -29,7 +29,6 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
         /// </summary>
         /// <param name="config">An object containing API credentials, a webhook verification token and other options.</param>
         public WebexAdapter(IWebexAdapterOptions config)
-            : base()
         {
             if (string.IsNullOrWhiteSpace(_config.AccessToken))
             {
@@ -42,14 +41,9 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
             }
 
             _config = config;
-            _api = TeamsAPI.CreateVersion1Client(config.AccessToken);
-
-            if (_api == null)
-            {
-                throw new Exception("Could not create the Webex Teams API client");
-            }
-
             _config.PublicAddress = new Uri(_config.PublicAddress).Host;
+            _api = TeamsAPI.CreateVersion1Client(_config.AccessToken)
+                   ?? throw new Exception("Could not create the Webex Teams API client");
         }
 
         /// <summary>


### PR DESCRIPTION
_**Note:** This PR is based on PR #178 and will be rebased once that one is merged._
## Read before reviewing
I recommend reviewing this PR commit by commit, as it contains gradual changes that might not be obvious if the final changes are compared directly with the base code.

Most complex commit changes contain a body with a brief explanation.

## Improvements left for future changes
The following changes were not done as they are more complex than the changes intended for this PR.
### Keep refactoring DecryptedMessageToActivityAsync
[DecryptedMessageToActivityAsync](https://github.com/southworkscom/botbuilder-dotnet/blob/856e85183bd8a935c589035fa8ae13f4c9236665/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexAdapter.cs) is still to big and does multiple things.
Ideally the following lines should be extracted to a private method. https://github.com/southworkscom/botbuilder-dotnet/blob/a39bc8533dede5c4ffe21dfd636b08e58d4c7136/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexAdapter.cs#L323-L342

### Regex not used as regex
I can't test it, but I am almost sure the regex variable created in the following line is not being used as a regex at all. 
https://github.com/southworkscom/botbuilder-dotnet/blob/a39bc8533dede5c4ffe21dfd636b08e58d4c7136/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexAdapter.cs#L325
The only instances in which it is used is in `if (!decryptedMessage.Html.Equals(pattern))` and `pattern.ToString()`. In both cases the regex it is being used as a `string`.

### Avoid using Regex
Using regexes is quite performance costly.
https://github.com/southworkscom/botbuilder-dotnet/blob/a39bc8533dede5c4ffe21dfd636b08e58d4c7136/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexAdapter.cs#L323-L342
The only match is done in line 329:
https://github.com/southworkscom/botbuilder-dotnet/blob/a39bc8533dede5c4ffe21dfd636b08e58d4c7136/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexAdapter.cs#L329
Find alternatives if possible, or move the usage of regexes to a static helper.

### Avoid magic numbers
There is a magic number in line 330:
https://github.com/southworkscom/botbuilder-dotnet/blob/a39bc8533dede5c4ffe21dfd636b08e58d4c7136/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexAdapter.cs#L330
What happens if `match` has nothing in index 1? What if it doesn't find anything at all? At the moment it is assumed that it will always find at least two matches, but there should be some kind of control if it doesn't.

### Use enum for event types
Check if the SDK/API for the adapter already has an enum with the event types, otherwise create one for the adapter.
https://github.com/southworkscom/botbuilder-dotnet/blob/a39bc8533dede5c4ffe21dfd636b08e58d4c7136/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexAdapter.cs#L319
It is preferred over a hardcoded string.