### PR TITLE
[TwilioAdapter] Replace TwilioAdapter bare Exceptions

### DIFF
--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Twilio/TwilioAdapter.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Twilio/TwilioAdapter.cs
@@ -33,21 +33,21 @@ namespace Microsoft.Bot.Builder.Adapters.Twilio
 
             if (string.IsNullOrWhiteSpace(options.TwilioNumber))
             {
-                throw new Exception("TwilioNumber is a required part of the configuration.");
+                throw new ArgumentException("TwilioNumber is a required part of the configuration.", nameof(options));
             }
 
             if (string.IsNullOrWhiteSpace(options.AccountSid))
             {
-                throw new Exception("AccountSid is a required part of the configuration.");
+                throw new ArgumentException("AccountSid is a required part of the configuration.", nameof(options));
             }
 
             if (string.IsNullOrWhiteSpace(options.AuthToken))
             {
-                throw new Exception("AuthToken is a required part of the configuration.");
+                throw new ArgumentException("AuthToken is a required part of the configuration.", nameof(options));
             }
 
+            _twilioApi = twilioApi ?? throw new ArgumentNullException(nameof(twilioApi));
             _options = options;
-            _twilioApi = twilioApi ?? throw new Exception("'twilioApi' is required.");
 
             _twilioApi.LogIn(_options.AccountSid, _options.AuthToken);
         }

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Twilio/TwilioAdapter.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Twilio/TwilioAdapter.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Bot.Builder.Adapters.Twilio
                 }
                 else
                 {
-                    throw new Exception("Unknown message type");
+                    throw new ArgumentException("Unknown message type of Activity.", nameof(activities));
                 }
             }
 

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Twilio.Tests/TwilioAdapterTests.cs
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Twilio.Tests/TwilioAdapterTests.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Bot.Builder.Adapters.Twilio.Tests
             options.Object.AuthToken = "Test";
             options.Object.AccountSid = "Test";
 
-            Assert.Throws<Exception>(() => { new TwilioAdapter(options.Object, new Mock<ITwilioClient>().Object); });
+            Assert.Throws<ArgumentException>(() => { new TwilioAdapter(options.Object, new Mock<ITwilioClient>().Object); });
         }
 
         [Fact]
@@ -39,7 +39,7 @@ namespace Microsoft.Bot.Builder.Adapters.Twilio.Tests
             options.Object.AuthToken = "Test";
             options.Object.TwilioNumber = "Test";
 
-            Assert.Throws<Exception>(() => { new TwilioAdapter(options.Object, new Mock<ITwilioClient>().Object); });
+            Assert.Throws<ArgumentException>(() => { new TwilioAdapter(options.Object, new Mock<ITwilioClient>().Object); });
         }
 
         [Fact]
@@ -50,7 +50,7 @@ namespace Microsoft.Bot.Builder.Adapters.Twilio.Tests
             options.Object.TwilioNumber = "Test";
             options.Object.AccountSid = "Test";
 
-            Assert.Throws<Exception>(() => { new TwilioAdapter(options.Object, new Mock<ITwilioClient>().Object); });
+            Assert.Throws<ArgumentException>(() => { new TwilioAdapter(options.Object, new Mock<ITwilioClient>().Object); });
         }
 
         [Fact]
@@ -62,7 +62,7 @@ namespace Microsoft.Bot.Builder.Adapters.Twilio.Tests
             options.Object.AccountSid = "Test";
             options.Object.AuthToken = "Test";
 
-            Assert.Throws<Exception>(() => { new TwilioAdapter(options.Object, null); });
+            Assert.Throws<ArgumentNullException>(() => { new TwilioAdapter(options.Object, null); });
         }
 
         [Fact]

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Twilio.Tests/TwilioAdapterTests.cs
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Twilio.Tests/TwilioAdapterTests.cs
@@ -95,7 +95,7 @@ namespace Microsoft.Bot.Builder.Adapters.Twilio.Tests
 
             Activity[] activities = { activity };
 
-            await Assert.ThrowsAsync<Exception>(async () =>
+            await Assert.ThrowsAsync<ArgumentException>(async () =>
             {
                 await twilioAdapter.SendActivitiesAsync(new TurnContext(twilioAdapter, activity), activities, default);
             });


### PR DESCRIPTION
Fixes ISSUE 2415

## Description
Replaced bare _Exception_ with `ArgumentException` and `ArgumentNullException` in the `TwilioAdapter.cs` file.

## More Details
Replaced _TwilioAdapter_'s constructor bare `Exception` with `ArgumentException` and `ArgumentNullException` respectively.
![image](https://user-images.githubusercontent.com/43762887/63169276-c04e2c80-c00c-11e9-8776-ac87c80e80d0.png)

Also, updated _SendActivitiesAsync_ method for replacing an `Exception` an `ArgumentException`:
![image](https://user-images.githubusercontent.com/43762887/63170004-a1e93080-c00e-11e9-84bb-9d75eeec4ebe.png)

All the test methods successfully passed:
![image](https://user-images.githubusercontent.com/43762887/63170485-be399d00-c00f-11e9-96dd-8e4588994989.png)
