### PR TITLE
[TwilioAdapter] [Conversations API] Add support to event type

### DIFF
--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Twilio/TwilioHelper.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Twilio/TwilioHelper.cs
@@ -86,11 +86,11 @@ namespace Microsoft.Bot.Builder.Adapters.Twilio
                 ChannelId = Channels.Twilio,
                 Conversation = new ConversationAccount()
                 {
-                    Id = twilioMessage.From,
+                    Id = twilioMessage.From ?? twilioMessage.Author,
                 },
                 From = new ChannelAccount()
                 {
-                    Id = twilioMessage.From,
+                    Id = twilioMessage.From ?? twilioMessage.Author,
                 },
                 Recipient = new ChannelAccount()
                 {

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Twilio/TwilioMessage.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Twilio/TwilioMessage.cs
@@ -142,5 +142,11 @@ namespace Microsoft.Bot.Builder.Adapters.Twilio
         /// </summary>
         /// <value>The API version used to process the message.</value>
         public string ApiVersion { get; set; }
+
+        /// <summary>
+        /// Gets or sets the event type for using with Twilio Conversation API.
+        /// </summary>
+        /// <value>The type of event, e.g. "onMessageAdd", "onMessageAdded", "onConversationAdd".</value>
+        public string EventType { get; set; }
     }
 }

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Twilio/TwilioMessage.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Twilio/TwilioMessage.cs
@@ -12,6 +12,12 @@ namespace Microsoft.Bot.Builder.Adapters.Twilio
     public class TwilioMessage
     {
         /// <summary>
+        /// Gets or sets the Author of the message.
+        /// </summary>
+        /// <value>The Author of the message.</value>
+        public string Author { get; set; }
+
+        /// <summary>
         /// Gets or sets the receiver's country.
         /// </summary>
         /// <value>The receiver's country. E.g. "US".</value>


### PR DESCRIPTION
## Proposed Changes
Add an **EventType** property to the _TwilioMessage_ class, to handle event types when using Twilio's [Conversations API](https://www.twilio.com/docs/conversations).

## Details
Added an extra property (EventType) to the TwilioMessage class, in order to expose the[ event type](https://www.twilio.com/docs/conversations/conversations-webhooks#webhook-bodies) field when using Twilio's Conversations API, to be handled by a Bot utilizing the adapter.

This would be consumed as shown below, to evaluate the desired events, and act accordingly.
![image](https://user-images.githubusercontent.com/20074735/63179512-a91a3980-c022-11e9-992a-713fe941bfe9.png)
