### PR TITLE
[TwilioAdapter] Change GetResourceIdentifier method signature

### DIFF
--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Twilio/ITwilioClient.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Twilio/ITwilioClient.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Threading.Tasks;
+using Twilio.Rest.Api.V2010.Account;
 
 namespace Microsoft.Bot.Builder.Adapters.Twilio
 {
@@ -19,6 +20,6 @@ namespace Microsoft.Bot.Builder.Adapters.Twilio
         /// </summary>
         /// <param name="messageOptions">Object that represents the Twilio message options.</param>
         /// <returns>ID from Twilio message.</returns>
-        Task<string> GetResourceIdentifier(object messageOptions);
+        Task<string> SendMessage(CreateMessageOptions messageOptions);
     }
 }

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Twilio/TwilioAdapter.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Twilio/TwilioAdapter.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Bot.Builder.Adapters.Twilio
                 {
                     var messageOptions = TwilioHelper.ActivityToTwilio(activity, _options.TwilioNumber);
 
-                    var res = await _twilioApi.GetResourceIdentifier(messageOptions).ConfigureAwait(false);
+                    var res = await _twilioApi.SendMessage(messageOptions).ConfigureAwait(false);
 
                     var response = new ResourceResponse()
                     {

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Twilio/TwilioApi.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Twilio/TwilioApi.cs
@@ -20,11 +20,11 @@ namespace Microsoft.Bot.Builder.Adapters.Twilio
         }
 
         /// <summary>
-        /// Returns the resource ID from a message.
+        /// Sends a message and returns its resource ID.
         /// </summary>
         /// <param name="messageOptions">Object that represents the Twilio message options.</param>
-        /// <returns>ID from Twilio message.</returns>
-        public async Task<string> GetResourceIdentifier(object messageOptions)
+        /// <returns>ID from the created Twilio message.</returns>
+        public async Task<string> SendMessage(CreateMessageOptions messageOptions)
         {
             var messageResource = await MessageResource.CreateAsync((CreateMessageOptions)messageOptions).ConfigureAwait(false);
             return messageResource.Sid;

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Twilio.Tests/TwilioAdapterTests.cs
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Twilio.Tests/TwilioAdapterTests.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Bot.Schema;
 using Moq;
+using Twilio.Rest.Api.V2010.Account;
 using Xunit;
 
 namespace Microsoft.Bot.Builder.Adapters.Twilio.Tests
@@ -306,7 +307,7 @@ namespace Microsoft.Bot.Builder.Adapters.Twilio.Tests
             // Setup mocked Twilio API client
             const string resourceIdentifier = "Mocked Resource Identifier";
             var twilioApi = new Mock<ITwilioClient>();
-            twilioApi.Setup(x => x.GetResourceIdentifier(It.IsAny<object>())).Returns(Task.FromResult(resourceIdentifier));
+            twilioApi.Setup(x => x.SendMessage(It.IsAny<CreateMessageOptions>())).Returns(Task.FromResult(resourceIdentifier));
 
             // Create a new Twilio Adapter with the mocked classes and get the responses
             var twilioAdapter = new TwilioAdapter(options.Object, twilioApi.Object);


### PR DESCRIPTION
This fixes ISSUE 2413

## Proposed Changes
Change the parameter type in **GetResourceIdentifier** from object to **CreateMessageOptions**, since it's both created as that, and then immediately cast to that after being passed to the method.

Also, changed the name of the method to something better representing its function (**SendMessage**), since it creates and sends a message, and returns its resource identifier once sent.

**Modified classes:**
- ITwilioClient
- TwilioAdapter
- TwilioApi

Test methods updated accordingly and all of them passing.
![image](https://user-images.githubusercontent.com/20074735/63189641-c9ee8900-c03a-11e9-9a48-b4f8d6adaec4.png)
